### PR TITLE
Explicitly add Alpaca Markets dependencies

### DIFF
--- a/QuantConnect.AlpacaBrokerage/QuantConnect.AlpacaBrokerage.csproj
+++ b/QuantConnect.AlpacaBrokerage/QuantConnect.AlpacaBrokerage.csproj
@@ -31,6 +31,9 @@
 		<PackageReference Include="QuantConnect.Brokerages" Version="2.5.*" />
 		<PackageReference Include="Polly" Version="8.3.1" />
 		<PackageReference Include="MessagePack" Version="2.5.172" />
+		<!--Dependencies of Alpaca.Markets.dll-->
+		<PackageReference Include="System.Threading.Channels" Version="8.0.0" PrivateAssets="compile;contentfiles;build;analyzers" />
+		<PackageReference Include="System.IO.Pipelines" Version="8.0.0" PrivateAssets="compile;contentfiles;build;analyzers" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Explicitly add Alpaca Markets dependencies, since we are adding dll manuall since https://github.com/QuantConnect/Lean.Brokerages.Alpaca/pull/14 let's explicitly add the dependencies


Avoid data download error
```
System.IO.FileNotFoundException: Could not load file or assembly 'System.IO.Pipelines, Version=8.0.0.0, Culture=neutral,
PublicKeyToken=cc7b13ffcd2ddd51'. The system cannot find the file specified
```