### PR TITLE
Catch missing brokerage data config if used as IDQH only

### DIFF
--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.DataQueueHandler.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.DataQueueHandler.cs
@@ -65,7 +65,12 @@ public partial class AlpacaBrokerage : IDataQueueHandler
         // required for trading
         job.BrokerageData.TryGetValue("alpaca-access-token", out var accessToken);
 
-        var usePaperTrading = Convert.ToBoolean(job.BrokerageData["alpaca-paper-trading"]);
+        var usePaperTrading = false;
+        // might not be there if only used as a data source
+        if (job.BrokerageData.TryGetValue("alpaca-paper-trading", out var usePaper))
+        {
+            usePaperTrading = Convert.ToBoolean(usePaper);
+        }
 
         Initialize(apiKey, secretKey, accessToken, usePaperTrading, null, null);
         if (!IsConnected)


### PR DESCRIPTION
- Catch missing brokerage data config if used as IDQH only

<img width="468" alt="image" src="https://github.com/user-attachments/assets/bc12d7ed-b36b-4be0-a3c1-0e2796fd04f2">
