### PR TITLE
Feat: improve handling of Alpaca orders outside of Lean

### DIFF
--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
@@ -92,6 +92,13 @@ namespace QuantConnect.Brokerages.Alpaca
         internal readonly Dictionary<Guid, HashSet<Guid>> _duplicationExecutionOrderIdByBrokerageOrderId = [];
 
         /// <summary>
+        /// Tracks unsupported TimeInForce values detected during order conversion.
+        /// This allows the system to issue a warning for each unsupported TIF only once,
+        /// preventing duplicate messages when processing multiple orders.
+        /// </summary>
+        private readonly HashSet<AlpacaMarket.TimeInForce> _unsupportedTimeInForce = [];
+
+        /// <summary>
         /// Returns true if we're currently connected to the broker
         /// </summary>
         public override bool IsConnected => _connected;
@@ -285,76 +292,84 @@ namespace QuantConnect.Brokerages.Alpaca
             var orders = _tradingClient.ListOrdersAsync(new ListOrdersRequest() { OrderStatusFilter = OrderStatusFilter.Open }).SynchronouslyAwaitTaskResult();
 
             var leanOrders = new List<Order>();
-            var unsupportedTimeInForce = new HashSet<AlpacaMarket.TimeInForce>();
             foreach (var brokerageOrder in orders)
             {
-                if (brokerageOrder.Legs.Count > 1)
+                if (TryConvertToLeanOrder(brokerageOrder, out var leanOrder))
                 {
-                    // TODO: Implement OrderType.ComboMarket and OrderType.ComboLimit
-                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupportedOrderType", "Multi-leg orders are not currently supported."));
-                    continue;
+                    leanOrders.Add(leanOrder);
                 }
-
-                var orderProperties = new AlpacaOrderProperties();
-                if (!orderProperties.TryGetLeanTimeInForceByAlpacaTimeInForce(brokerageOrder.TimeInForce))
-                {
-                    if (unsupportedTimeInForce.Add(brokerageOrder.TimeInForce))
-                    {
-                        OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, -1, $"Detected unsupported Lean TimeInForce of '{brokerageOrder.TimeInForce}', ignoring. Using default: TimeInForce.GoodTilCanceled"));
-                    }
-                }
-
-                var leanSymbol = _symbolMapper.GetLeanSymbol(brokerageOrder.AssetClass, brokerageOrder.Symbol);
-                var quantity = (brokerageOrder.OrderSide == OrderSide.Buy ? brokerageOrder.Quantity : decimal.Negate(brokerageOrder.Quantity.Value)).Value;
-                var leanOrder = default(Order);
-                switch (brokerageOrder.OrderType)
-                {
-                    case AlpacaMarket.OrderType.Market:
-
-                        switch (brokerageOrder.TimeInForce)
-                        {
-                            case AlpacaMarket.TimeInForce.Opg:
-                                leanOrder = new MarketOnOpenOrder(leanSymbol, quantity, brokerageOrder.SubmittedAtUtc.Value, properties: orderProperties);
-                                break;
-                            case AlpacaMarket.TimeInForce.Cls:
-                                leanOrder = new MarketOnCloseOrder(leanSymbol, quantity, brokerageOrder.SubmittedAtUtc.Value, properties: orderProperties);
-                                break;
-                            default:
-                                leanOrder = new Orders.MarketOrder(leanSymbol, quantity, brokerageOrder.SubmittedAtUtc.Value, properties: orderProperties);
-                                break;
-                        }
-                        break;
-                    case AlpacaMarket.OrderType.Limit:
-                        leanOrder = new Orders.LimitOrder(leanSymbol, quantity, brokerageOrder.LimitPrice.Value, brokerageOrder.SubmittedAtUtc.Value, properties: orderProperties);
-                        break;
-                    case AlpacaMarket.OrderType.Stop:
-                        leanOrder = new StopMarketOrder(leanSymbol, quantity, brokerageOrder.StopPrice.Value, brokerageOrder.SubmittedAtUtc.Value, properties: orderProperties);
-                        break;
-                    case AlpacaMarket.OrderType.StopLimit:
-                        leanOrder = new Orders.StopLimitOrder(leanSymbol, quantity, brokerageOrder.StopPrice.Value, brokerageOrder.LimitPrice.Value, brokerageOrder.SubmittedAtUtc.Value, properties: orderProperties);
-                        break;
-                    case AlpacaMarket.OrderType.TrailingStop:
-                        var trailingAsPercent = brokerageOrder.TrailOffsetInPercent.HasValue ? true : false;
-                        var trailingAmount = brokerageOrder.TrailOffsetInPercent.HasValue ? brokerageOrder.TrailOffsetInPercent.Value / 100m : brokerageOrder.TrailOffsetInDollars.Value;
-                        leanOrder = new Orders.TrailingStopOrder(leanSymbol, quantity, brokerageOrder.StopPrice.Value, trailingAmount, trailingAsPercent, brokerageOrder.SubmittedAtUtc.Value, properties: orderProperties);
-                        break;
-                    default:
-                        throw new NotSupportedException($"{nameof(AlpacaBrokerage)}.{nameof(GetOpenOrders)}: Order type '{brokerageOrder.OrderType}' is not supported.");
-                }
-
-                leanOrder.Status = Orders.OrderStatus.Submitted;
-                if (brokerageOrder.FilledQuantity > 0 && brokerageOrder.FilledQuantity != brokerageOrder.Quantity)
-                {
-                    leanOrder.Status = Orders.OrderStatus.PartiallyFilled;
-                }
-
-                var brokerageOrderId = brokerageOrder.OrderId;
-                _duplicationExecutionOrderIdByBrokerageOrderId[brokerageOrderId] = [];
-                leanOrder.BrokerId.Add(brokerageOrderId.ToString());
-                leanOrders.Add(leanOrder);
             }
 
             return leanOrders;
+        }
+
+        private bool TryConvertToLeanOrder(IOrder brokerageOrder, out Order leanOrder)
+        {
+            leanOrder = null;
+            if (brokerageOrder.Legs.Count > 1)
+            {
+                // TODO: Implement OrderType.ComboMarket and OrderType.ComboLimit
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupportedOrderType", "Multi-leg orders are not currently supported."));
+                return false;
+            }
+
+            var orderProperties = new AlpacaOrderProperties();
+            if (!orderProperties.TryGetLeanTimeInForceByAlpacaTimeInForce(brokerageOrder.TimeInForce))
+            {
+                if (_unsupportedTimeInForce.Add(brokerageOrder.TimeInForce))
+                {
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, -1, $"Detected unsupported Lean TimeInForce of '{brokerageOrder.TimeInForce}', ignoring. Using default: TimeInForce.GoodTilCanceled"));
+                }
+            }
+
+            var leanSymbol = _symbolMapper.GetLeanSymbol(brokerageOrder.AssetClass, brokerageOrder.Symbol);
+            var quantity = (brokerageOrder.OrderSide == OrderSide.Buy ? brokerageOrder.Quantity : decimal.Negate(brokerageOrder.Quantity.Value)).Value;
+            switch (brokerageOrder.OrderType)
+            {
+                case AlpacaMarket.OrderType.Market:
+
+                    switch (brokerageOrder.TimeInForce)
+                    {
+                        case AlpacaMarket.TimeInForce.Opg:
+                            leanOrder = new MarketOnOpenOrder(leanSymbol, quantity, brokerageOrder.SubmittedAtUtc.Value, properties: orderProperties);
+                            break;
+                        case AlpacaMarket.TimeInForce.Cls:
+                            leanOrder = new MarketOnCloseOrder(leanSymbol, quantity, brokerageOrder.SubmittedAtUtc.Value, properties: orderProperties);
+                            break;
+                        default:
+                            leanOrder = new Orders.MarketOrder(leanSymbol, quantity, brokerageOrder.SubmittedAtUtc.Value, properties: orderProperties);
+                            break;
+                    }
+                    break;
+                case AlpacaMarket.OrderType.Limit:
+                    leanOrder = new Orders.LimitOrder(leanSymbol, quantity, brokerageOrder.LimitPrice.Value, brokerageOrder.SubmittedAtUtc.Value, properties: orderProperties);
+                    break;
+                case AlpacaMarket.OrderType.Stop:
+                    leanOrder = new StopMarketOrder(leanSymbol, quantity, brokerageOrder.StopPrice.Value, brokerageOrder.SubmittedAtUtc.Value, properties: orderProperties);
+                    break;
+                case AlpacaMarket.OrderType.StopLimit:
+                    leanOrder = new Orders.StopLimitOrder(leanSymbol, quantity, brokerageOrder.StopPrice.Value, brokerageOrder.LimitPrice.Value, brokerageOrder.SubmittedAtUtc.Value, properties: orderProperties);
+                    break;
+                case AlpacaMarket.OrderType.TrailingStop:
+                    var trailingAsPercent = brokerageOrder.TrailOffsetInPercent.HasValue ? true : false;
+                    var trailingAmount = brokerageOrder.TrailOffsetInPercent.HasValue ? brokerageOrder.TrailOffsetInPercent.Value / 100m : brokerageOrder.TrailOffsetInDollars.Value;
+                    leanOrder = new Orders.TrailingStopOrder(leanSymbol, quantity, brokerageOrder.StopPrice.Value, trailingAmount, trailingAsPercent, brokerageOrder.SubmittedAtUtc.Value, properties: orderProperties);
+                    break;
+                default:
+                    throw new NotSupportedException($"{nameof(AlpacaBrokerage)}.{nameof(GetOpenOrders)}: Order type '{brokerageOrder.OrderType}' is not supported.");
+            }
+
+            leanOrder.Status = Orders.OrderStatus.Submitted;
+            if (brokerageOrder.FilledQuantity > 0 && brokerageOrder.FilledQuantity != brokerageOrder.Quantity)
+            {
+                leanOrder.Status = Orders.OrderStatus.PartiallyFilled;
+            }
+
+            var brokerageOrderId = brokerageOrder.OrderId;
+            _duplicationExecutionOrderIdByBrokerageOrderId[brokerageOrderId] = [];
+            leanOrder.BrokerId.Add(brokerageOrderId.ToString());
+
+            return true;
         }
 
         /// <summary>
@@ -446,6 +461,24 @@ namespace QuantConnect.Brokerages.Alpaca
                 if (!TryGetOrRemoveCrossZeroOrder(brokerageOrderId, newLeanOrderStatus, out var leanOrder))
                 {
                     leanOrder = _orderProvider.GetOrdersByBrokerageId(brokerageOrderId)?.SingleOrDefault();
+                    if (leanOrder == null)
+                    {
+                        if (TryConvertToLeanOrder(obj.Order, out leanOrder))
+                        {
+                            OnNewBrokerageOrderNotification(new(leanOrder));
+
+                            if (leanOrder.Id == 0)
+                            {
+                                leanOrder = null;
+                            }
+                            else
+                            {
+                                OnOrderEvent(new OrderEvent(leanOrder, DateTime.UtcNow, OrderFee.Zero, $"Order was submitted outside Lean")
+                                { Status = Orders.OrderStatus.Submitted });
+                                return;
+                            }
+                        }
+                    }
                 }
                 if (leanOrder == null)
                 {
@@ -468,7 +501,14 @@ namespace QuantConnect.Brokerages.Alpaca
                         {
                             if (newLeanOrderStatus == Orders.OrderStatus.UpdateSubmitted)
                             {
-                                _duplicationExecutionOrderIdByBrokerageOrderId[obj.Order.ReplacedByOrderId.Value] = [];
+                                var replacedBrokerageOrderId = obj.Order.ReplacedByOrderId.Value;
+                                // If the order already exists in the BrokerId list, it means the update was initiated by Lean.
+                                // Otherwise, the order was updated outside of Lean and we need to notify about the new brokerage ID.
+                                if (!leanOrder.BrokerId.Contains(replacedBrokerageOrderId.ToString()))
+                                {
+                                    OnOrderIdChangedEvent(new() { OrderId = leanOrder.Id, BrokerId = [replacedBrokerageOrderId.ToString()] });
+                                }
+                                _duplicationExecutionOrderIdByBrokerageOrderId[replacedBrokerageOrderId] = [];
                             }
 
                             if (!_tradeEventReason.TryGetValue(obj.Event, out var message))

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -356,9 +356,7 @@ namespace QuantConnect.Brokerages.Alpaca
                     leanOrder = new Orders.TrailingStopOrder(leanSymbol, quantity, brokerageOrder.StopPrice.Value, trailingAmount, trailingAsPercent, brokerageOrder.SubmittedAtUtc.Value, properties: orderProperties);
                     break;
                 default:
-                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupportedOrderType",
-                        $"Order type '{brokerageOrder.OrderType}' is not currently supported. Details {brokerageOrder}"));
-                    return false;
+                    throw new NotSupportedException($"{nameof(AlpacaBrokerage)}.{nameof(GetOpenOrders)}: Order type '{brokerageOrder.OrderType}' is not supported.");
             }
 
             leanOrder.Status = Orders.OrderStatus.Submitted;
@@ -471,10 +469,16 @@ namespace QuantConnect.Brokerages.Alpaca
                         {
                             OnOrderEvent(new OrderEvent(leanOrder, DateTime.UtcNow, OrderFee.Zero, $"Order was submitted outside Lean")
                             { Status = Orders.OrderStatus.Submitted });
-                            return;
-                        }
 
-                        leanOrder = null;
+                            if (newLeanOrderStatus == Orders.OrderStatus.Submitted)
+                            {
+                                return;
+                            }
+                        }
+                        else
+                        {
+                            leanOrder = null;
+                        }
                     }
                 }
                 if (leanOrder == null)

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
@@ -356,7 +356,9 @@ namespace QuantConnect.Brokerages.Alpaca
                     leanOrder = new Orders.TrailingStopOrder(leanSymbol, quantity, brokerageOrder.StopPrice.Value, trailingAmount, trailingAsPercent, brokerageOrder.SubmittedAtUtc.Value, properties: orderProperties);
                     break;
                 default:
-                    throw new NotSupportedException($"{nameof(AlpacaBrokerage)}.{nameof(GetOpenOrders)}: Order type '{brokerageOrder.OrderType}' is not supported.");
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupportedOrderType",
+                        $"Order type '{brokerageOrder.OrderType}' is not currently supported. Details {brokerageOrder}"));
+                    return false;
             }
 
             leanOrder.Status = Orders.OrderStatus.Submitted;
@@ -461,23 +463,18 @@ namespace QuantConnect.Brokerages.Alpaca
                 if (!TryGetOrRemoveCrossZeroOrder(brokerageOrderId, newLeanOrderStatus, out var leanOrder))
                 {
                     leanOrder = _orderProvider.GetOrdersByBrokerageId(brokerageOrderId)?.SingleOrDefault();
-                    if (leanOrder == null)
+                    if (leanOrder == null && TryConvertToLeanOrder(obj.Order, out leanOrder))
                     {
-                        if (TryConvertToLeanOrder(obj.Order, out leanOrder))
-                        {
-                            OnNewBrokerageOrderNotification(new(leanOrder));
+                        OnNewBrokerageOrderNotification(new(leanOrder));
 
-                            if (leanOrder.Id == 0)
-                            {
-                                leanOrder = null;
-                            }
-                            else
-                            {
-                                OnOrderEvent(new OrderEvent(leanOrder, DateTime.UtcNow, OrderFee.Zero, $"Order was submitted outside Lean")
-                                { Status = Orders.OrderStatus.Submitted });
-                                return;
-                            }
+                        if (leanOrder.Id != 0)
+                        {
+                            OnOrderEvent(new OrderEvent(leanOrder, DateTime.UtcNow, OrderFee.Zero, $"Order was submitted outside Lean")
+                            { Status = Orders.OrderStatus.Submitted });
+                            return;
                         }
+
+                        leanOrder = null;
                     }
                 }
                 if (leanOrder == null)


### PR DESCRIPTION
#### Description
- Implement `OnNewBrokerageOrderNotification(...)` about outside execution orders.

#### Related PRs
- https://github.com/QuantConnect/Lean/issues/7686

#### Related Issue
N/a

#### Motivation and Context
Handle outside orders and see events in Lean.

#### Requires Documentation Change
N/a

#### How Has This Been Tested?
I have run the algo:
```
public override void Initialize()
{
    // Prevent warning when we have tried to place Option orders
    UniverseSettings.DataNormalizationMode = DataNormalizationMode.Raw;

    _aapl = AddEquity("AAPL", Resolution.Minute, extendedMarketHours: true, fillForward: false);

    // Handler of manually created orders
    SetBrokerageMessageHandler(new CustomBrokerageMessageHandler(this));
}

public override void OnData(Slice slice)
{
    switch (_step)
    {
        case 0:
            _step += 1;
            _ticket = LimitOrder(_aapl, 1, sec.AskPrice - 5m);
            break;
        case 1:
            _step += 1;
            _ticket.UpdateLimitPrice(sec.AskPrice - 1m);
            MarketOrder(_aapl, -2);
            break;
        case 2:
            _step += 1;
            _ticket.Cancel();
            break;
    }
}
```
And parallel created a Limit Order in Alpaca Web Page UI:
<img width="1805" height="557" alt="image" src="https://github.com/user-attachments/assets/47959983-057b-4b67-b33c-3c75429c56e7" />
> **OrderID 1** - Lean Order, **OrderID 2** - created manually in Alpaca Web UI.


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
