### PR TITLE
fix: populate Tick.Exchange on streaming Alpaca ticks

### DIFF
--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.Messaging.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.Messaging.cs
@@ -126,9 +126,12 @@ public partial class AlpacaBrokerage
             TickType = TickType.Trade,
             Symbol = subscriptionData.Symbol,
             Time = DateTime.UtcNow.ConvertFromUtc(subscriptionData.ExchangeTimeZone),
-            Exchange = obj.Exchange.ToString(),
             SaleCondition = obj.Conditions != null ? string.Join(",", obj.Conditions) : string.Empty,
         };
+        if (AlpacaBrokerageExtensions.TryGetExchange(obj.Exchange, out var tradeExchange))
+        {
+            tick.Exchange = tradeExchange;
+        }
         lock (_aggregator)
         {
             _aggregator.Update(tick);
@@ -158,8 +161,11 @@ public partial class AlpacaBrokerage
             TickType = TickType.Quote,
             Symbol = subscriptionData.Symbol,
             Time = DateTime.UtcNow.ConvertFromUtc(subscriptionData.ExchangeTimeZone),
-            Exchange = obj.AskExchange.ToString(),
         };
+        if (AlpacaBrokerageExtensions.TryGetExchange(obj.AskExchange, out var askExchange))
+        {
+            tick.Exchange = askExchange;
+        }
 
         lock (_aggregator)
         {

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.Messaging.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.Messaging.cs
@@ -126,12 +126,8 @@ public partial class AlpacaBrokerage
             TickType = TickType.Trade,
             Symbol = subscriptionData.Symbol,
             Time = DateTime.UtcNow.ConvertFromUtc(subscriptionData.ExchangeTimeZone),
-            SaleCondition = obj.Conditions != null ? string.Join(",", obj.Conditions) : string.Empty,
+            Exchange = AlpacaBrokerageExtensions.GetExchange(obj.Exchange),
         };
-        if (AlpacaBrokerageExtensions.TryGetExchange(obj.Exchange, out var tradeExchange))
-        {
-            tick.Exchange = tradeExchange;
-        }
         lock (_aggregator)
         {
             _aggregator.Update(tick);
@@ -161,11 +157,8 @@ public partial class AlpacaBrokerage
             TickType = TickType.Quote,
             Symbol = subscriptionData.Symbol,
             Time = DateTime.UtcNow.ConvertFromUtc(subscriptionData.ExchangeTimeZone),
+            Exchange = AlpacaBrokerageExtensions.GetExchange(obj.AskExchange),
         };
-        if (AlpacaBrokerageExtensions.TryGetExchange(obj.AskExchange, out var askExchange))
-        {
-            tick.Exchange = askExchange;
-        }
 
         lock (_aggregator)
         {

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.Messaging.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.Messaging.cs
@@ -126,6 +126,8 @@ public partial class AlpacaBrokerage
             TickType = TickType.Trade,
             Symbol = subscriptionData.Symbol,
             Time = DateTime.UtcNow.ConvertFromUtc(subscriptionData.ExchangeTimeZone),
+            Exchange = obj.Exchange.ToString(),
+            SaleCondition = obj.Conditions != null ? string.Join(",", obj.Conditions) : string.Empty,
         };
         lock (_aggregator)
         {
@@ -156,6 +158,7 @@ public partial class AlpacaBrokerage
             TickType = TickType.Quote,
             Symbol = subscriptionData.Symbol,
             Time = DateTime.UtcNow.ConvertFromUtc(subscriptionData.ExchangeTimeZone),
+            Exchange = obj.AskExchange.ToString(),
         };
 
         lock (_aggregator)

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.Messaging.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.Messaging.cs
@@ -126,7 +126,7 @@ public partial class AlpacaBrokerage
             TickType = TickType.Trade,
             Symbol = subscriptionData.Symbol,
             Time = DateTime.UtcNow.ConvertFromUtc(subscriptionData.ExchangeTimeZone),
-            Exchange = obj.Exchange.GetExchange(subscriptionData.Symbol.SecurityType),
+            Exchange = obj.Exchange.GetPrimaryExchange(subscriptionData.Symbol.SecurityType).Name,
         };
         lock (_aggregator)
         {
@@ -157,7 +157,7 @@ public partial class AlpacaBrokerage
             TickType = TickType.Quote,
             Symbol = subscriptionData.Symbol,
             Time = DateTime.UtcNow.ConvertFromUtc(subscriptionData.ExchangeTimeZone),
-            Exchange = obj.AskExchange.GetExchange(subscriptionData.Symbol.SecurityType),
+            Exchange = obj.AskExchange.GetPrimaryExchange(subscriptionData.Symbol.SecurityType).Name,
         };
 
         lock (_aggregator)

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.Messaging.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.Messaging.cs
@@ -126,7 +126,7 @@ public partial class AlpacaBrokerage
             TickType = TickType.Trade,
             Symbol = subscriptionData.Symbol,
             Time = DateTime.UtcNow.ConvertFromUtc(subscriptionData.ExchangeTimeZone),
-            Exchange = AlpacaBrokerageExtensions.GetExchange(obj.Exchange),
+            Exchange = obj.Exchange.GetExchange(subscriptionData.Symbol.SecurityType),
         };
         lock (_aggregator)
         {
@@ -157,7 +157,7 @@ public partial class AlpacaBrokerage
             TickType = TickType.Quote,
             Symbol = subscriptionData.Symbol,
             Time = DateTime.UtcNow.ConvertFromUtc(subscriptionData.ExchangeTimeZone),
-            Exchange = AlpacaBrokerageExtensions.GetExchange(obj.AskExchange),
+            Exchange = obj.AskExchange.GetExchange(subscriptionData.Symbol.SecurityType),
         };
 
         lock (_aggregator)

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerageExtensions.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerageExtensions.cs
@@ -26,29 +26,6 @@ namespace QuantConnect.Brokerages.Alpaca;
 public static class AlpacaBrokerageExtensions
 {
     /// <summary>
-    /// Maps an Alpaca stock-exchange code (single SIP/CTS letter) to the Lean
-    /// <see cref="Exchange"/> name, deferring to <see cref="Exchanges.GetPrimaryExchange"/>
-    /// and hard-coding the few codes that Lean's equity switch does not reach.
-    /// </summary>
-    /// <remarks>
-    /// Source: GET /v2/stocks/meta/exchanges
-    /// <see href="https://docs.alpaca.markets/reference/stockmetaexchanges-1"/>.
-    /// Unmapped codes return <see cref="Exchange.UNKNOWN"/>'s name — the empty string —
-    /// which matches <see cref="Data.Market.Tick.Exchange"/>'s default.
-    /// </remarks>
-    /// <param name="exchangeCode">The Alpaca exchange code (e.g. "N", "Q", "D").</param>
-    /// <param name="securityType">The type of security (e.g., Equity, Option, Crypto).</param>
-    /// <returns>The Lean exchange name, or an empty string when no venue is known.</returns>
-    public static string GetExchange(this string exchangeCode, SecurityType securityType)
-    {
-        if (string.Equals(exchangeCode, "E")) // Market Independent (Genesrated by Nasdaq SIP)
-        {
-            return Exchange.UNKNOWN;
-        }
-        return exchangeCode.GetPrimaryExchange(securityType).Name;
-    }
-
-    /// <summary>
     /// Creates an Alpaca sell order based on the provided Lean order type.
     /// </summary>
     /// <param name="order">The order object containing details for the trade.</param>

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerageExtensions.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerageExtensions.cs
@@ -16,7 +16,6 @@
 using System;
 using QuantConnect.Orders;
 using QuantConnect.Logging;
-using System.Collections.Generic;
 using AlpacaMarket = Alpaca.Markets;
 using QuantConnect.Orders.TimeInForces;
 
@@ -27,53 +26,37 @@ namespace QuantConnect.Brokerages.Alpaca;
 public static class AlpacaBrokerageExtensions
 {
     /// <summary>
-    /// Alpaca stock exchange codes mapped to a Lean <see cref="Exchange"/> name when a Lean
-    /// counterpart exists; otherwise the raw Alpaca display name is used as the fallback.
+    /// Maps an Alpaca stock-exchange code (single SIP/CTS letter) to the Lean
+    /// <see cref="Exchange"/> name, deferring to <see cref="Exchanges.GetPrimaryExchange"/>
+    /// and hard-coding the few codes that Lean's equity switch does not reach.
     /// </summary>
-    /// <remarks>Source: GET /v2/stocks/meta/exchanges <see href="https://docs.alpaca.markets/reference/stockmetaexchanges-1"/></remarks>
-    private static readonly Dictionary<string, string> _leanExchangeNameByAlpacaCode = new()
-    {
-        { "A", Exchange.AMEX.Name },
-        { "B", Exchange.NASDAQ_BX.Name },
-        { "C", Exchange.NSX.Name },
-        { "D", Exchange.FINRA.Name },
-        { "E", "Market Independent" },
-        { "H", Exchange.MIAX_PEARL.Name },
-        { "I", Exchange.ISE.Name },
-        { "J", Exchange.EDGA.Name },
-        { "K", Exchange.EDGX.Name },
-        { "L", Exchange.LTSE.Name },
-        { "M", Exchange.CSE.Name },
-        { "N", Exchange.NYSE.Name },
-        { "P", Exchange.ARCA.Name },
-        { "Q", Exchange.NASDAQ.Name },
-        { "S", "NASDAQ Small Cap" },
-        { "T", "NASDAQ Int" },
-        { "U", Exchange.MEMX.Name },
-        { "V", Exchange.IEX.Name },
-        { "W", Exchange.CBOE.Name },
-        { "X", Exchange.NASDAQ_PSX.Name },
-        { "Y", Exchange.BATS_Y.Name },
-        { "Z", Exchange.BATS.Name },
-    };
-
-    /// <summary>
-    /// Maps an Alpaca exchange code (single SIP/CTS letter) to a Lean exchange name,
-    /// falling back to the Alpaca-provided display name when no Lean venue exists.
-    /// </summary>
+    /// <remarks>
+    /// Source: GET /v2/stocks/meta/exchanges
+    /// <see href="https://docs.alpaca.markets/reference/stockmetaexchanges-1"/>.
+    /// Unmapped codes return <see cref="Exchange.UNKNOWN"/>'s name — the empty string —
+    /// which matches <see cref="Data.Market.Tick.Exchange"/>'s default.
+    /// </remarks>
     /// <param name="exchangeCode">The Alpaca exchange code (e.g. "N", "Q", "D").</param>
-    /// <param name="exchange">The resolved exchange name, or <c>null</c> when no mapping exists.</param>
-    /// <returns>
-    /// <c>false</c> when <paramref name="exchangeCode"/> is null/empty or unknown; otherwise <c>true</c>.
-    /// </returns>
-    public static bool TryGetExchange(string exchangeCode, out string exchange)
+    /// <returns>The Lean exchange name, or an empty string when no venue is known.</returns>
+    public static string GetExchange(string exchangeCode)
     {
-        if (string.IsNullOrEmpty(exchangeCode))
+        // Alpaca codes Lean's equity branch of GetPrimaryExchange does not reach.
+        // "S" (NASDAQ Small Cap) folds into Exchange.NASDAQ — Lean models the NASDAQ
+        // family as a single venue, same way "T" (NASDAQ Int) is handled inside
+        // GetPrimaryExchange below.
+        switch (exchangeCode)
         {
-            exchange = null;
-            return false;
+            case "H":
+                return Exchange.MIAX.Name;
+            case "S":
+                return Exchange.NASDAQ.Name;
+            case "U":
+                return Exchange.MEMX.Name;
+            case "V":
+                return Exchange.IEX.Name;
         }
-        return _leanExchangeNameByAlpacaCode.TryGetValue(exchangeCode, out exchange);
+
+        return exchangeCode.GetPrimaryExchange().Name;
     }
 
     /// <summary>

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerageExtensions.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerageExtensions.cs
@@ -16,6 +16,7 @@
 using System;
 using QuantConnect.Orders;
 using QuantConnect.Logging;
+using System.Collections.Generic;
 using AlpacaMarket = Alpaca.Markets;
 using QuantConnect.Orders.TimeInForces;
 
@@ -25,6 +26,56 @@ namespace QuantConnect.Brokerages.Alpaca;
 
 public static class AlpacaBrokerageExtensions
 {
+    /// <summary>
+    /// Alpaca stock exchange codes mapped to a Lean <see cref="Exchange"/> name when a Lean
+    /// counterpart exists; otherwise the raw Alpaca display name is used as the fallback.
+    /// </summary>
+    /// <remarks>Source: GET /v2/stocks/meta/exchanges <see href="https://docs.alpaca.markets/reference/stockmetaexchanges-1"/></remarks>
+    private static readonly Dictionary<string, string> _leanExchangeNameByAlpacaCode = new()
+    {
+        { "A", Exchange.AMEX.Name },
+        { "B", Exchange.NASDAQ_BX.Name },
+        { "C", Exchange.NSX.Name },
+        { "D", Exchange.FINRA.Name },
+        { "E", "Market Independent" },
+        { "H", Exchange.MIAX_PEARL.Name },
+        { "I", Exchange.ISE.Name },
+        { "J", Exchange.EDGA.Name },
+        { "K", Exchange.EDGX.Name },
+        { "L", Exchange.LTSE.Name },
+        { "M", Exchange.CSE.Name },
+        { "N", Exchange.NYSE.Name },
+        { "P", Exchange.ARCA.Name },
+        { "Q", Exchange.NASDAQ.Name },
+        { "S", "NASDAQ Small Cap" },
+        { "T", "NASDAQ Int" },
+        { "U", Exchange.MEMX.Name },
+        { "V", Exchange.IEX.Name },
+        { "W", Exchange.CBOE.Name },
+        { "X", Exchange.NASDAQ_PSX.Name },
+        { "Y", Exchange.BATS_Y.Name },
+        { "Z", Exchange.BATS.Name },
+    };
+
+    /// <summary>
+    /// Maps an Alpaca exchange code (single SIP/CTS letter) to a Lean exchange name,
+    /// falling back to the Alpaca-provided display name when no Lean venue exists.
+    /// </summary>
+    /// <param name="exchangeCode">The Alpaca exchange code (e.g. "N", "Q", "D").</param>
+    /// <param name="exchange">The resolved exchange name, or <c>null</c> when no mapping exists.</param>
+    /// <returns>
+    /// <c>false</c> when <paramref name="exchangeCode"/> is null/empty or unknown; otherwise <c>true</c>.
+    /// </returns>
+    public static bool TryGetExchange(string exchangeCode, out string exchange)
+    {
+        if (string.IsNullOrEmpty(exchangeCode))
+        {
+            exchange = null;
+            return false;
+        }
+        return _leanExchangeNameByAlpacaCode.TryGetValue(exchangeCode, out exchange);
+    }
+
     /// <summary>
     /// Creates an Alpaca sell order based on the provided Lean order type.
     /// </summary>

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerageExtensions.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerageExtensions.cs
@@ -41,16 +41,10 @@ public static class AlpacaBrokerageExtensions
     /// <returns>The Lean exchange name, or an empty string when no venue is known.</returns>
     public static string GetExchange(this string exchangeCode, SecurityType securityType)
     {
-        switch (exchangeCode)
+        if (string.Equals(exchangeCode, "E")) // Market Independent (Genesrated by Nasdaq SIP)
         {
-            case "E": // Market Independent (Genesrated by Nasdaq SIP)
-                return Exchange.UNKNOWN;
-            case "H":
-                return Exchange.MIAX.Name;
-            case "U":
-                return Exchange.MEMX.Name;
+            return Exchange.UNKNOWN;
         }
-
         return exchangeCode.GetPrimaryExchange(securityType).Name;
     }
 

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerageExtensions.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerageExtensions.cs
@@ -37,26 +37,21 @@ public static class AlpacaBrokerageExtensions
     /// which matches <see cref="Data.Market.Tick.Exchange"/>'s default.
     /// </remarks>
     /// <param name="exchangeCode">The Alpaca exchange code (e.g. "N", "Q", "D").</param>
+    /// <param name="securityType">The type of security (e.g., Equity, Option, Crypto).</param>
     /// <returns>The Lean exchange name, or an empty string when no venue is known.</returns>
-    public static string GetExchange(string exchangeCode)
+    public static string GetExchange(this string exchangeCode, SecurityType securityType)
     {
-        // Alpaca codes Lean's equity branch of GetPrimaryExchange does not reach.
-        // "S" (NASDAQ Small Cap) folds into Exchange.NASDAQ — Lean models the NASDAQ
-        // family as a single venue, same way "T" (NASDAQ Int) is handled inside
-        // GetPrimaryExchange below.
         switch (exchangeCode)
         {
+            case "E": // Market Independent (Genesrated by Nasdaq SIP)
+                return Exchange.UNKNOWN;
             case "H":
                 return Exchange.MIAX.Name;
-            case "S":
-                return Exchange.NASDAQ.Name;
             case "U":
                 return Exchange.MEMX.Name;
-            case "V":
-                return Exchange.IEX.Name;
         }
 
-        return exchangeCode.GetPrimaryExchange().Name;
+        return exchangeCode.GetPrimaryExchange(securityType).Name;
     }
 
     /// <summary>


### PR DESCRIPTION
#### Description
Populate `Tick.Exchange` on streaming trade and quote ticks from the Alpaca SIP feed by mapping the single-letter SIP exchange code to a Lean `Exchange` name.

#### Related PR(s)
Depends on Lean PR [#9422](https://github.com/QuantConnect/Lean/pull/9422) (adds equity-tape mappings for `S`, `T`, `V`, `H`, `U` to `Exchanges.GetPrimaryExchange`). Without it, those Alpaca SIP codes fall through to `Exchange.UNKNOWN` here (and `T` is conflated with `NASDAQ`).

#### Related Issue
Sale-condition follow-up: #62.

#### Motivation and Context
Alpaca's SDK exposes the SIP exchange tag on every trade/quote, but `HandleTradeReceived` / `HandleQuoteReceived` were dropping it. Without the venue, microstructure strategies cannot distinguish lit exchange prints from off-exchange (FINRA/ADF) prints or compute venue-aware volume profiles.

#### Implementation
At the two tick construction sites in `AlpacaBrokerage.Messaging.cs`, set `Tick.Exchange` directly from the SIP code via Lean's `GetPrimaryExchange(SecurityType).Name`:

```csharp
// HandleTradeReceived
Exchange = obj.Exchange.GetPrimaryExchange(subscriptionData.Symbol.SecurityType).Name,

// HandleQuoteReceived
Exchange = obj.AskExchange.GetPrimaryExchange(subscriptionData.Symbol.SecurityType).Name,
```

Codes with no Lean counterpart resolve to `Exchange.UNKNOWN.Name` (empty string), which matches `Tick.Exchange`'s default.

The Alpaca Exchange codes: [doc](https://docs.alpaca.markets/reference/stockmetaexchanges-1)
```
{
  "A": "NYSE American (AMEX)",
  "B": "NASDAQ OMX BX",
  "C": "National Stock Exchange",
  "D": "FINRA ADF",
  "E": "Market Independent",
  "H": "MIAX",
  "I": "International Securities Exchange",
  "J": "Cboe EDGA",
  "K": "Cboe EDGX",
  "L": "Long Term Stock Exchange",
  "M": "Chicago Stock Exchange",
  "N": "New York Stock Exchange",
  "P": "NYSE Arca",
  "Q": "NASDAQ OMX",
  "S": "NASDAQ Small Cap",
  "T": "NASDAQ Int",
  "U": "Members Exchange",
  "V": "IEX",
  "W": "CBOE",
  "X": "NASDAQ OMX PSX",
  "Y": "Cboe BYX",
  "Z": "Cboe BZ"
}
```

> Mappings below assume Lean PR [#9422](https://github.com/QuantConnect/Lean/pull/9422) has been merged.

| Alpaca code | Alpaca exchange name | Lean accepted codes | Lean `Exchange` enum | Match status |
|:-----------:|----------------------|---------------------|----------------------|--------------|
| `A` | NYSE American (AMEX) | `A`, `AMEX` | `Exchange.AMEX` | ✅ Exact |
| `B` | NASDAQ OMX BX | `B`, `NASDAQ BX`, `NASDAQ_BX` | `Exchange.NASDAQ_BX` | ✅ Exact |
| `C` | National Stock Exchange | `C`, `NSX`, `NSE` | `Exchange.NSX` *(US market)* | ✅ Exact *(market-aware)* |
| `D` | FINRA ADF | `D`, `FINRA` | `Exchange.FINRA` | ✅ Exact |
| `E` | Market Independent | — | *Not mapped* | ❌ None |
| `H` | MIAX | `H` | `Exchange.MIAX_PEARL` | ✅ Exact |
| `I` | International Securities Exchange | `I`, `ISE` | `Exchange.ISE` | ✅ Exact |
| `J` | Cboe EDGA | `J`, `EDGA` | `Exchange.EDGA` | ✅ Exact |
| `K` | Cboe EDGX | `K`, `EDGX` | `Exchange.EDGX` | ✅ Exact |
| `L` | Long Term Stock Exchange | `L`, `LTSE` | `Exchange.LTSE` | ✅ Exact |
| `M` | Chicago Stock Exchange | `M`, `CSE` | `Exchange.CSE` | ✅ Exact *(CHX → CSE)* |
| `N` | New York Stock Exchange | `N`, `NYSE` | `Exchange.NYSE` | ✅ Exact |
| `P` | NYSE Arca | `P`, `ARCA` | `Exchange.ARCA` | ✅ Exact |
| `Q` | NASDAQ OMX | `Q`, `T`, `NASDAQ`, `NASDAQ_OMX` | `Exchange.NASDAQ` | ✅ Exact |
| `S` | NASDAQ Small Cap | `S`, `NASDAQ_SC` | `Exchange.NASDAQ_SC` | ✅ Exact |
| `T` | NASDAQ Int | `T`, `NASDAQ_INT` | `Exchange.NASDAQ_INT` | ✅ Exact |
| `U` | Members Exchange | `U`, `MM`, `MEMX` | `Exchange.MEMX` | ✅ Exact |
| `V` | IEX | `IEX` | `Exchange.IEX` | ✅ Exact  |
| `W` | CBOE | `W`, `CBOE` | `Exchange.CBOE` | ✅ Exact |
| `X` | NASDAQ OMX PSX | `X`, `NASDAQ PSX`, `NASDAQ_PSX` | `Exchange.NASDAQ_PSX` | ✅ Exact |
| `Y` | Cboe BYX | `Y`, `BYX`, `BATS Y`, `BATS_Y` | `Exchange.BATS_Y` | ✅ Exact |
| `Z` | Cboe BZ | `Z`, `BATS`, `BATS Z`, `BATS_Z` | `Exchange.BATS` | ✅ Exact |

`Tick.SaleCondition` is intentionally **not** populated. Alpaca's SIP conditions are tape-specific single-character codes (`"@"`, `"I"`, `"T"`), not a hex `uint`, so `Tick.ParsedSaleCondition` would throw `FormatException`. A tape-aware decoder that folds Alpaca codes into Lean's `TradeConditionFlags` / `QuoteConditionFlags` is tracked in #62.

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
Live streaming test with Alpaca SIP (Algo Trader Plus) subscription via LEAN from source.
```
Before: exch= empty on all ticks
TRADE #1: AAPL px=254.45 sz=121.0 exch= sus=False

After:
TRADE #1: AAPL px=254.11 sz=4.0  exch=FINRA  sus=False
TRADE #3: AAPL px=254.02 sz=5.0  exch=EDGA   sus=False
QUOTE #1: AAPL bid=254.00x100.0 ask=254.15x100.0 exch=NASDAQ
```

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
