### PR TITLE
Fix GetCashBalance using margin-inflated TradableCash

### DIFF
--- a/QuantConnect.AlpacaBrokerage.Tests/AlpacaBrokerageCashSyncTests.cs
+++ b/QuantConnect.AlpacaBrokerage.Tests/AlpacaBrokerageCashSyncTests.cs
@@ -1,0 +1,38 @@
+using Moq;
+using System.Threading;
+using Alpaca.Markets;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace QuantConnect.Brokerages.Alpaca.Tests
+{
+    [TestFixture]
+    public class AlpacaBrokerageCashSyncTests
+    {
+        [Test]
+        public void GetCashBalance_UsesCashNotBuyingPower()
+        {
+            var mockAccount = new Mock<IAccount>();
+            mockAccount.Setup(a => a.NonMarginableBuyingPower).Returns(346.58m);
+            mockAccount.Setup(a => a.TradableCash).Returns(46300.11m);
+            mockAccount.Setup(a => a.Currency).Returns("USD");
+
+            var mockTradingClient = new Mock<IAlpacaTradingClient>();
+            mockTradingClient
+                .Setup(c => c.GetAccountAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mockAccount.Object);
+
+            var brokerage = new AlpacaBrokerage();
+            typeof(AlpacaBrokerage)
+                .GetField("_tradingClient", BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(brokerage, mockTradingClient.Object);
+
+            var result = brokerage.GetCashBalance();
+
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(346.58m, result[0].Amount);
+            Assert.AreEqual("USD", result[0].Currency);
+        }
+    }
+}

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
@@ -405,7 +405,8 @@ namespace QuantConnect.Brokerages.Alpaca
         public override List<CashAmount> GetCashBalance()
         {
             var accounts = _tradingClient.GetAccountAsync().SynchronouslyAwaitTaskResult();
-            return new List<CashAmount>() { new(accounts.TradableCash, accounts.Currency) };
+            return new List<CashAmount>() { new(accounts.NonMarginableBuyingPower ?? 0m, accounts.Currency) };
+
         }
 
         /// <summary>


### PR DESCRIPTION
Addressing issue #58

TradableCash reflects buying power (2x-4x on margin accounts), not actual cash. This caused PerformCashSync to compute incorrect deltas after fills, corrupting portfolio state. Fix: use NonMarginableBuyingPower instead.


<!--- Provide a general summary of your changes in the Title above -->

#### Description
**GetCashBalance** was returning **TradableCash** which on margin accounts reflects buying power (2x-4x multiplied), not actual settled cash.

#### Related Issue
Fixes #58

#### Motivation and Context
**TradableCash** is margin-inflated. This caused **PerformCashSync** to compute incorrect deltas after order fills, corrupting portfolio state and driving margin negative. **NonMarginableBuyingPower** is unaffected by the margin multiplier and accurately reflects available cash.

#### Requires Documentation Change
No

#### How Has This Been Tested?
Added **AlpacaBrokerageCashSyncTests** — a mock-based unit test that injects a fake **IAlpacaTradingClient** returning different values for **NonMarginableBuyingPower** and **TradableCash**, and asserts **GetCashBalance** returns the correct one. All tests pass.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
