### PR TITLE
fix: gate order operations on trade_updates stream readiness (#58)

### DIFF
--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
@@ -265,16 +265,16 @@ namespace QuantConnect.Brokerages.Alpaca
             Log.Trace($"{nameof(StreamingClient_SocketClosed)}({client.GetStreamingClientName()}): SocketClosed");
             if (_connected)
             {
-                _connected = false;
-                // let consumers know, we will try to reconnect internally, if we can't lean will kill us
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Disconnect, "Disconnected", "Brokerage Disconnected"));
-                _reconnectionResetEvent.Set();
                 // Order-stream-specific: gate PlaceOrder/UpdateOrder/CancelOrder while the stream is down.
                 if (client == _orderStreamingClient)
                 {
                     Log.Trace($"{nameof(StreamingClient_SocketClosed)}({client.GetStreamingClientName()}): order stream closed; blocking order operations until reconnect.");
                     _orderStreamReadyEvent.Reset();
                 }
+                _connected = false;
+                // let consumers know, we will try to reconnect internally, if we can't lean will kill us
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Disconnect, "Disconnected", "Brokerage Disconnected"));
+                _reconnectionResetEvent.Set();
             }
         }
 

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
@@ -74,6 +74,16 @@ namespace QuantConnect.Brokerages.Alpaca
         private bool _isInitialized;
         private bool _connected;
 
+        /// <summary>
+        /// Latch gating <see cref="BrokerageMessageType.Disconnect"/> emission so it fires
+        /// exactly once per disconnect cycle. Set on the first stream close and cleared only
+        /// when <see cref="ReconnectionLogic"/> confirms all streams are back up, so market-data
+        /// streams bouncing through <c>TooManyConnections</c> during reconnect do not produce
+        /// duplicate Disconnect events. Guarded by <see cref="_disconnectNotifiedLock"/>.
+        /// </summary>
+        private bool _disconnectNotified;
+        private readonly object _disconnectNotifiedLock = new();
+
         private readonly ManualResetEvent _reconnectionResetEvent = new(false);
         private readonly CancellationTokenSource _cancellationTokenSource = new();
 
@@ -196,10 +206,6 @@ namespace QuantConnect.Brokerages.Alpaca
             {
                 _orderStreamingClient.OnTradeUpdate += (message) => _messageHandler.HandleNewMessage(message);
                 WireStreamingClientEvents(_orderStreamingClient);
-                // Order-stream-specific lifecycle: toggle _orderStreamReadyEvent so
-                // PlaceOrder/UpdateOrder/CancelOrder wait while the stream is down.
-                _orderStreamingClient.SocketClosed += OrderStreamingClient_SocketClosed;
-                _orderStreamingClient.Connected += OrderStreamingClient_Connected;
             }
             _messageHandler = new(HandleTradeUpdate, ConcurrencyEnabled);
             _symbolMapper = new AlpacaBrokerageSymbolMapper(_tradingClient);
@@ -268,6 +274,33 @@ namespace QuantConnect.Brokerages.Alpaca
         {
             Log.Trace($"{nameof(StreamingClient_SocketClosed)}({client.GetStreamingClientName()}): SocketClosed");
             _reconnectionResetEvent.Set();
+
+            // Emit Disconnect once per cycle, for any stream. The latch is cleared by ReconnectionLogic
+            // only after a FULL successful reconnect, so data streams flapping during reconnect do not
+            // produce duplicate events even though Connect() has already restored _connected.
+            bool shouldNotify;
+            lock (_disconnectNotifiedLock)
+            {
+                shouldNotify = !_disconnectNotified;
+                if (shouldNotify)
+                {
+                    _disconnectNotified = true;
+                    _connected = false;
+                }
+            }
+
+            if (shouldNotify)
+            {
+                // let consumers know, we will try to reconnect internally, if we can't lean will kill us
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Disconnect, "Disconnected", "Brokerage Disconnected"));
+            }
+
+            // Order-stream-specific: gate PlaceOrder/UpdateOrder/CancelOrder while the stream is down.
+            if (client == _orderStreamingClient)
+            {
+                Log.Trace($"{nameof(StreamingClient_SocketClosed)}({client.GetStreamingClientName()}): order stream closed; blocking order operations until reconnect.");
+                _orderStreamReadyEvent.Reset();
+            }
         }
 
         private void StreamingClient_SocketOpened(IStreamingClient client)
@@ -283,25 +316,10 @@ namespace QuantConnect.Brokerages.Alpaca
         private void StreamingClient_Connected(IStreamingClient client, AuthStatus obj)
         {
             Log.Trace($"{nameof(StreamingClient_Connected)}({client.GetStreamingClientName()}): {obj}");
-        }
 
-        private void OrderStreamingClient_SocketClosed()
-        {
-            Log.Trace($"{nameof(AlpacaBrokerage)}.{nameof(OrderStreamingClient_SocketClosed)}: order stream closed; blocking order operations until reconnect.");
-            if (_connected)
+            if (client == _orderStreamingClient && obj == AuthStatus.Authorized)
             {
-                _connected = false;
-                // let consumers know, we will try to reconnect internally, if we can't lean will kill us
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Disconnect, "Disconnected", "Brokerage Disconnected"));
-                _orderStreamReadyEvent.Reset();
-            }
-        }
-
-        private void OrderStreamingClient_Connected(AuthStatus status)
-        {
-            if (status == AuthStatus.Authorized)
-            {
-                Log.Trace($"{nameof(AlpacaBrokerage)}.{nameof(OrderStreamingClient_Connected)}: order stream authorized; releasing order operations.");
+                Log.Trace($"{nameof(StreamingClient_Connected)}({client.GetStreamingClientName()}): order stream authorized; releasing order operations.");
                 _orderStreamReadyEvent.Set();
             }
         }
@@ -817,6 +835,8 @@ namespace QuantConnect.Brokerages.Alpaca
                         break;
                     }
 
+                    _reconnectionResetEvent.Reset();
+
                     try
                     {
                         Connect();
@@ -835,8 +855,14 @@ namespace QuantConnect.Brokerages.Alpaca
                                 Unsubscribe(symbols);
                                 Subscribe(symbols);
                             }
-                            _reconnectionResetEvent.Reset();
                             attempt = 0;
+                            // Re-arm the Disconnect latch: only after a FULL reconnect
+                            // (order stream restored + data streams resubscribed) do we
+                            // allow the next stream loss to emit Disconnect again.
+                            lock (_disconnectNotifiedLock)
+                            {
+                                _disconnectNotified = false;
+                            }
                             // let consumers know we are reconnected, avoid lean killing us
                             OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Reconnect, "Reconnected", "Brokerage Reconnected"));
                         }

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
@@ -267,13 +267,7 @@ namespace QuantConnect.Brokerages.Alpaca
         private void StreamingClient_SocketClosed(IStreamingClient client)
         {
             Log.Trace($"{nameof(StreamingClient_SocketClosed)}({client.GetStreamingClientName()}): SocketClosed");
-            if (_connected)
-            {
-                _connected = false;
-                // let consumers know, we will try to reconnect internally, if we can't lean will kill us
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Disconnect, "Disconnected", "Brokerage Disconnected"));
-                _reconnectionResetEvent.Set();
-            }
+            _reconnectionResetEvent.Set();
         }
 
         private void StreamingClient_SocketOpened(IStreamingClient client)
@@ -294,7 +288,13 @@ namespace QuantConnect.Brokerages.Alpaca
         private void OrderStreamingClient_SocketClosed()
         {
             Log.Trace($"{nameof(AlpacaBrokerage)}.{nameof(OrderStreamingClient_SocketClosed)}: order stream closed; blocking order operations until reconnect.");
-            _orderStreamReadyEvent.Reset();
+            if (_connected)
+            {
+                _connected = false;
+                // let consumers know, we will try to reconnect internally, if we can't lean will kill us
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Disconnect, "Disconnected", "Brokerage Disconnected"));
+                _orderStreamReadyEvent.Reset();
+            }
         }
 
         private void OrderStreamingClient_Connected(AuthStatus status)
@@ -767,7 +767,7 @@ namespace QuantConnect.Brokerages.Alpaca
             var authorizedStatus = streamingClient.ConnectAndAuthenticateAsync().SynchronouslyAwaitTaskResult();
             if (authorizedStatus != AuthStatus.Authorized)
             {
-                throw new InvalidOperationException($"Connect(): Failed to connect to {streamingClient.GetStreamingClientName()}");
+                throw new InvalidOperationException($"Connect(): Failed to connect to {streamingClient.GetStreamingClientName()}. Status: {authorizedStatus}");
             }
         }
 
@@ -800,21 +800,22 @@ namespace QuantConnect.Brokerages.Alpaca
             Task.Factory.StartNew(() =>
             {
                 Log.Trace($"{nameof(AlpacaBrokerage)}.{nameof(ReconnectionLogic)}: Starting reconnection loop.");
+                var attempt = 0;
                 while (!_cancellationTokenSource.IsCancellationRequested)
                 {
                     _reconnectionResetEvent.WaitOne(_cancellationTokenSource.Token);
 
+                    var delay = TimeSpan.FromSeconds(5 * ++attempt);
+                    Log.Trace($"{nameof(AlpacaBrokerage)}.{nameof(ReconnectionLogic)}: attempt #{attempt}, waiting {delay.TotalSeconds}s...");
                     // The server enforces a 90-second timeout for "partially dead" connections.
                     // If another WebSocket connection is opened with the same API key/secret
                     // before the old one is fully closed, this may trigger the
                     // "Too many connections" error. Waiting here prevents premature reconnection
                     // attempts that would conflict with the server's timeout window.
-                    if (_cancellationTokenSource.Token.WaitHandle.WaitOne(TimeSpan.FromSeconds(90)))
+                    if (_cancellationTokenSource.Token.WaitHandle.WaitOne(delay))
                     {
                         break;
                     }
-
-                    _reconnectionResetEvent.Reset();
 
                     try
                     {
@@ -834,6 +835,8 @@ namespace QuantConnect.Brokerages.Alpaca
                                 Unsubscribe(symbols);
                                 Subscribe(symbols);
                             }
+                            _reconnectionResetEvent.Reset();
+                            attempt = 0;
                             // let consumers know we are reconnected, avoid lean killing us
                             OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Reconnect, "Reconnected", "Brokerage Reconnected"));
                         }

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
@@ -78,6 +78,13 @@ namespace QuantConnect.Brokerages.Alpaca
         private readonly CancellationTokenSource _cancellationTokenSource = new();
 
         /// <summary>
+        /// Signals when the order <c>trade_updates</c> stream is authorized and
+        /// able to deliver fill events. Order operations wait on this so REST
+        /// order placement cannot race a dead stream (issue #58).
+        /// </summary>
+        private readonly ManualResetEventSlim _orderStreamReadyEvent = new(initialState: false);
+
+        /// <summary>
         /// Provides user-facing reason messages for specific trade events.
         /// Used when emitting order events.
         /// </summary>
@@ -189,6 +196,10 @@ namespace QuantConnect.Brokerages.Alpaca
             {
                 _orderStreamingClient.OnTradeUpdate += (message) => _messageHandler.HandleNewMessage(message);
                 WireStreamingClientEvents(_orderStreamingClient);
+                // Order-stream-specific lifecycle: toggle _orderStreamReadyEvent so
+                // PlaceOrder/UpdateOrder/CancelOrder wait while the stream is down.
+                _orderStreamingClient.SocketClosed += OrderStreamingClient_SocketClosed;
+                _orderStreamingClient.Connected += OrderStreamingClient_Connected;
             }
             _messageHandler = new(HandleTradeUpdate, ConcurrencyEnabled);
             _symbolMapper = new AlpacaBrokerageSymbolMapper(_tradingClient);
@@ -278,6 +289,21 @@ namespace QuantConnect.Brokerages.Alpaca
         private void StreamingClient_Connected(IStreamingClient client, AuthStatus obj)
         {
             Log.Trace($"{nameof(StreamingClient_Connected)}({client.GetStreamingClientName()}): {obj}");
+        }
+
+        private void OrderStreamingClient_SocketClosed()
+        {
+            Log.Trace($"{nameof(AlpacaBrokerage)}.{nameof(OrderStreamingClient_SocketClosed)}: order stream closed; blocking order operations until reconnect.");
+            _orderStreamReadyEvent.Reset();
+        }
+
+        private void OrderStreamingClient_Connected(AuthStatus status)
+        {
+            if (status == AuthStatus.Authorized)
+            {
+                Log.Trace($"{nameof(AlpacaBrokerage)}.{nameof(OrderStreamingClient_Connected)}: order stream authorized; releasing order operations.");
+                _orderStreamReadyEvent.Set();
+            }
         }
 
         #region Brokerage
@@ -423,7 +449,7 @@ namespace QuantConnect.Brokerages.Alpaca
 
             try
             {
-                _messageHandler.WithLockedStream(() =>
+                ExecuteWhenReconnectedAndStreamLocked(nameof(PlaceOrder), () =>
                 {
                     var holdingQuantity = _securityProvider.GetHoldingsQuantity(order.Symbol);
                     var isPlaceCrossOrder = TryCrossZeroPositionOrder(order, holdingQuantity);
@@ -618,7 +644,7 @@ namespace QuantConnect.Brokerages.Alpaca
             try
             {
                 IOrder response = null;
-                _messageHandler.WithLockedStream(() =>
+                ExecuteWhenReconnectedAndStreamLocked(nameof(UpdateOrder), () =>
                 {
                     response = _tradingClient.PatchOrderAsync(pathOrderRequest).SynchronouslyAwaitTaskResult();
                     if (response == null || response.OrderStatus == AlpacaMarket.OrderStatus.Rejected)
@@ -664,7 +690,7 @@ namespace QuantConnect.Brokerages.Alpaca
             try
             {
                 var response = false;
-                _messageHandler.WithLockedStream(() =>
+                ExecuteWhenReconnectedAndStreamLocked(nameof(CancelOrder), () =>
                 {
                     var brokerageOrderId = new Guid(order.BrokerId.Last());
                     response = _tradingClient.CancelOrderAsync(brokerageOrderId).SynchronouslyAwaitTaskResult();
@@ -745,6 +771,30 @@ namespace QuantConnect.Brokerages.Alpaca
             }
         }
 
+        /// <summary>
+        /// Runs <paramref name="action"/> through <see cref="BrokerageConcurrentMessageHandler{T}.WithLockedStream"/>,
+        /// but first waits for the order <c>trade_updates</c> stream to be authorized.
+        /// Prevents REST order placement from racing a dead stream and losing
+        /// subsequent fill events (issue #58).
+        /// </summary>
+        private void ExecuteWhenReconnectedAndStreamLocked(string methodName, Action action)
+        {
+            if (!_orderStreamReadyEvent.IsSet)
+            {
+                Log.Trace($"{nameof(AlpacaBrokerage)}.{nameof(ExecuteWhenReconnectedAndStreamLocked)}.{methodName}: waiting for order stream reconnect...");
+                try
+                {
+                    _orderStreamReadyEvent.Wait(_cancellationTokenSource.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+                Log.Trace($"{nameof(AlpacaBrokerage)}.{nameof(ExecuteWhenReconnectedAndStreamLocked)}.{methodName}: order stream ready.");
+            }
+            _messageHandler.WithLockedStream(action);
+        }
+
         private void ReconnectionLogic()
         {
             Task.Factory.StartNew(() =>
@@ -814,6 +864,7 @@ namespace QuantConnect.Brokerages.Alpaca
         {
             _cancellationTokenSource?.Cancel();
             _cancellationTokenSource?.DisposeSafely();
+            _orderStreamReadyEvent?.DisposeSafely();
 
             _tradingClient.DisposeSafely();
 

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
@@ -802,7 +802,11 @@ namespace QuantConnect.Brokerages.Alpaca
                 Log.Trace($"{nameof(AlpacaBrokerage)}.{nameof(ExecuteWhenReconnectedAndStreamLocked)}.{methodName}: waiting for order stream reconnect...");
                 try
                 {
-                    _orderStreamReadyEvent.Wait(_cancellationTokenSource.Token);
+                    if (!_orderStreamReadyEvent.Wait(TimeSpan.FromMinutes(10), _cancellationTokenSource.Token))
+                    {
+                        Log.Error($"{nameof(AlpacaBrokerage)}.{nameof(ExecuteWhenReconnectedAndStreamLocked)}.{methodName}: order stream not ready after 10 minutes; skipping {methodName}.");
+                        return;
+                    }
                 }
                 catch (OperationCanceledException)
                 {

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
@@ -74,16 +74,6 @@ namespace QuantConnect.Brokerages.Alpaca
         private bool _isInitialized;
         private bool _connected;
 
-        /// <summary>
-        /// Latch gating <see cref="BrokerageMessageType.Disconnect"/> emission so it fires
-        /// exactly once per disconnect cycle. Set on the first stream close and cleared only
-        /// when <see cref="ReconnectionLogic"/> confirms all streams are back up, so market-data
-        /// streams bouncing through <c>TooManyConnections</c> during reconnect do not produce
-        /// duplicate Disconnect events. Guarded by <see cref="_disconnectNotifiedLock"/>.
-        /// </summary>
-        private bool _disconnectNotified;
-        private readonly object _disconnectNotifiedLock = new();
-
         private readonly ManualResetEvent _reconnectionResetEvent = new(false);
         private readonly CancellationTokenSource _cancellationTokenSource = new();
 
@@ -273,33 +263,18 @@ namespace QuantConnect.Brokerages.Alpaca
         private void StreamingClient_SocketClosed(IStreamingClient client)
         {
             Log.Trace($"{nameof(StreamingClient_SocketClosed)}({client.GetStreamingClientName()}): SocketClosed");
-            _reconnectionResetEvent.Set();
-
-            // Emit Disconnect once per cycle, for any stream. The latch is cleared by ReconnectionLogic
-            // only after a FULL successful reconnect, so data streams flapping during reconnect do not
-            // produce duplicate events even though Connect() has already restored _connected.
-            bool shouldNotify;
-            lock (_disconnectNotifiedLock)
+            if (_connected)
             {
-                shouldNotify = !_disconnectNotified;
-                if (shouldNotify)
-                {
-                    _disconnectNotified = true;
-                    _connected = false;
-                }
-            }
-
-            if (shouldNotify)
-            {
+                _connected = false;
                 // let consumers know, we will try to reconnect internally, if we can't lean will kill us
                 OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Disconnect, "Disconnected", "Brokerage Disconnected"));
-            }
-
-            // Order-stream-specific: gate PlaceOrder/UpdateOrder/CancelOrder while the stream is down.
-            if (client == _orderStreamingClient)
-            {
-                Log.Trace($"{nameof(StreamingClient_SocketClosed)}({client.GetStreamingClientName()}): order stream closed; blocking order operations until reconnect.");
-                _orderStreamReadyEvent.Reset();
+                _reconnectionResetEvent.Set();
+                // Order-stream-specific: gate PlaceOrder/UpdateOrder/CancelOrder while the stream is down.
+                if (client == _orderStreamingClient)
+                {
+                    Log.Trace($"{nameof(StreamingClient_SocketClosed)}({client.GetStreamingClientName()}): order stream closed; blocking order operations until reconnect.");
+                    _orderStreamReadyEvent.Reset();
+                }
             }
         }
 
@@ -860,13 +835,6 @@ namespace QuantConnect.Brokerages.Alpaca
                                 Subscribe(symbols);
                             }
                             attempt = 0;
-                            // Re-arm the Disconnect latch: only after a FULL reconnect
-                            // (order stream restored + data streams resubscribed) do we
-                            // allow the next stream loss to emit Disconnect again.
-                            lock (_disconnectNotifiedLock)
-                            {
-                                _disconnectNotified = false;
-                            }
                             // let consumers know we are reconnected, avoid lean killing us
                             OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Reconnect, "Reconnected", "Brokerage Reconnected"));
                         }


### PR DESCRIPTION
#### Description
  Prevents `PlaceOrder` / `UpdateOrder` / `CancelOrder` from hitting the Alpaca REST API while the `trade_updates` WebSocket is disconnected. A `ManualResetEventSlim` (`_orderStreamReadyEvent`) is toggled by the shared `StreamingClient_SocketClosed` / `StreamingClient_Connected` handlers (when the client is `_orderStreamingClient`), and an `ExecuteWhenReconnectedAndStreamLocked(methodName, action)` wrapper - replaces direct `_messageHandler.WithLockedStream(...)` calls so order operations block until the stream is authorized again. The wait is bounded by a 10-minute timeout that logs and skips the action rather than hanging.

  Follow-up hardening in the reconnect / messaging path:
  - **Linear backoff** in `ReconnectionLogic`: `5 * attempt` seconds (5, 10, 15, …) per attempt instead of a fixed 90s sleep, reset only after a successful reconnect.
 
#### Related PR(s)
[#39](https://github.com/QuantConnect/Lean.Brokerages.Alpaca/pull/39) - introduced the original 90-second reconnect cooldown. This PR replaces the blanket wait with per-attempt linear backoff while preserving the same safety intent around Alpaca's connection-limit enforcement.

#### Related Issue
  closes #58

  #### Motivation and Context
  **Bug.** Alpaca allows only one active real-time WebSocket per API key/secret; on an unclean disconnect the slot is held "partially dead" for ~90 seconds before another socket is accepted. During that window, any `trade_updates` (order acks, fills, cancels) Alpaca emits are dropped - the SDK has no replay.
  The REST trading API stays reachable throughout, so `PostOrderAsync` happily places an order that Alpaca then fills silently, from Lean's point of view.
  At the next `PerformCashSync` (inherited, not overridden), Lean pulls Alpaca's post-fill `cash` and overwrites its pre-fill ledger, turning `MarginRemaining` negative and corrupting subsequent portfolio math.

  Customer syslog `L-0474e298690cf6ea227faa42875ee3ef` (2026-03-20) shows it end-to-end:

  | Time (UTC) | Event |
  |---|---|
  | 16:59:29 | `StreamingClient: Disconnected` |
  | 17:00:04.76 | Order 23 submitted: buy 79 QQQ. MarginRemaining: $46,807.96 |
  | 17:00:04.82 | Alpaca acks `Submitted` via REST |
  | 17:00:09.76 | `ERROR: Order did not fill within 5 seconds` |
  | 17:00:59 | `StreamingClient: Reconnected` (Authorized) |
  | 18:40:04 | Cancel 23 → rejected: "order is already in 'filled' state" |
  | 2026-03-21 11:45:00 | `PerformCashSync(): USD Delta: 46300.11` |

  79 × ~$586 ≈ $46,300 - the sync delta matches the missed fill to the dollar.

  **Solution.** Preventive, not corrective. Gate order operations on order-stream readiness so the lost-fill race cannot be reached through Lean:
- `_orderStreamReadyEvent` reflects the order client's authorization state (set on `Connected(Authorized)`, reset on `SocketClosed`) - toggled inside the shared `StreamingClient_*` handlers when the client is `_orderStreamingClient`.
- `ExecuteWhenReconnectedAndStreamLocked` blocks on that event (respecting `_cancellationTokenSource`, bounded by a 10-minute timeout), then delegates to `_messageHandler.WithLockedStream`.
- `PlaceOrder` / `UpdateOrder` / `CancelOrder` go through the wrapper.
- `ReconnectionLogic` uses linear 5s-per-attempt backoff; the server-enforced 90-second "partially dead" timeout still bounds how fast we can actually re-authorize, but it is no longer duplicated as a blanket client-side sleep.

Order operations now pause for up to the reconnect window on a real outage, which is strictly better than silently losing fills.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Manual replay of the customer scenario on paper account: force-close `_orderStreamingClient` mid-flow; `PlaceOrder` logs the "waiting for order stream reconnect…" trace and then completes cleanly once the stream reauthorizes, with no lost fills and `PerformCashSync()` reporting `USD Delta: 0` the following morning.
- Existing `AlpacaBrokerageTests` order-type suite continues to pass (regression guard on `HandleTradeUpdate` and the `_messageHandler.WithLockedStream` path).

<img width="1225" height="196" alt="image" src="https://github.com/user-attachments/assets/46585730-e9ca-4141-beda-6b9582fce609" />

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`