### PR TITLE
fix: skip trade updates on closed lean order to drop replayed fills

### DIFF
--- a/QuantConnect.AlpacaBrokerage.Tests/AlpacaBrokerageTests.cs
+++ b/QuantConnect.AlpacaBrokerage.Tests/AlpacaBrokerageTests.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using TradeEvent = Alpaca.Markets.TradeEvent;
+using OrderSide = Alpaca.Markets.OrderSide;
 using QuantConnect.Brokerages.Alpaca.Tests.Models;
 using static QuantConnect.Brokerages.Alpaca.Tests.AlpacaBrokerageAdditionalTests;
 
@@ -442,8 +443,8 @@ namespace QuantConnect.Brokerages.Alpaca.Tests
             {
                 new(TradeEvent.PendingNew, null, new TestOrder(orderId)),
                 new(TradeEvent.New, Guid.NewGuid(), new TestOrder(orderId)),
-                new(TradeEvent.PartialFill, Guid.NewGuid(), new TestOrder(orderId, 1)),
-                new(TradeEvent.Fill, Guid.NewGuid(), new TestOrder(orderId, 3))
+                new(TradeEvent.PartialFill, Guid.NewGuid(), new TestOrder(orderId, 1, OrderSide.Buy)),
+                new(TradeEvent.Fill, Guid.NewGuid(), new TestOrder(orderId, 3, OrderSide.Buy))
             };
 
             foreach (var tradeUpdate in tradeUpdates)
@@ -464,7 +465,7 @@ namespace QuantConnect.Brokerages.Alpaca.Tests
                         Assert.AreEqual(0, AlpacaBrokerage._duplicationExecutionOrderIdByBrokerageOrderId.Count);
                         break;
                 }
-            }            
+            }
         }
 
         [Test]
@@ -555,19 +556,19 @@ namespace QuantConnect.Brokerages.Alpaca.Tests
             };
 
             var partialFillExecutionId_1 = Guid.NewGuid();
-            var partialFill_1 = new TestTradeUpdate(TradeEvent.PartialFill, partialFillExecutionId_1, new TestOrder(orderId, 1));
+            var partialFill_1 = new TestTradeUpdate(TradeEvent.PartialFill, partialFillExecutionId_1, new TestOrder(orderId, 1, OrderSide.Buy));
 
             tradeUpdates.Add(partialFill_1);
             tradeUpdates.Add(partialFill_1);
 
             var partialFillExecutionId_2 = Guid.NewGuid();
-            var partialFill_2 = new TestTradeUpdate(TradeEvent.PartialFill, partialFillExecutionId_2, new TestOrder(orderId, 2));
+            var partialFill_2 = new TestTradeUpdate(TradeEvent.PartialFill, partialFillExecutionId_2, new TestOrder(orderId, 2, OrderSide.Buy));
 
             tradeUpdates.Add(partialFill_2);
             tradeUpdates.Add(partialFill_2);
 
             var fillExecutionId = Guid.NewGuid();
-            var fill = new TestTradeUpdate(TradeEvent.Fill, fillExecutionId, new TestOrder(orderId, 3));
+            var fill = new TestTradeUpdate(TradeEvent.Fill, fillExecutionId, new TestOrder(orderId, 3, OrderSide.Buy));
 
             tradeUpdates.Add(fill);
             tradeUpdates.Add(fill);
@@ -704,6 +705,62 @@ namespace QuantConnect.Brokerages.Alpaca.Tests
                         break;
                 }
             }
+        }
+
+        [Test]
+        public void HandleTradeUpdateShouldSkipFillDuplicationWithReplayedNew()
+        {
+            // Alpaca replay scenario: pending_new -> new -> fill, then the same new + fill
+            // are redelivered with identical execution_ids. Only one Filled OrderEvent should
+            // be emitted regardless of how many times the new/fill pair is replayed.
+            var orderId = Guid.NewGuid();
+
+            var order = new MarketOrder(Symbols.AAPL, -967m, default);
+            order.BrokerId.Add(orderId.ToString());
+            OrderProvider.Add(order);
+
+            var newExecutionId = Guid.NewGuid();
+            var fillExecutionId = Guid.NewGuid();
+
+            var pendingNew = new TestTradeUpdate(TradeEvent.PendingNew, null, new TestOrder(orderId));
+            var newUpdate = new TestTradeUpdate(TradeEvent.New, newExecutionId, new TestOrder(orderId));
+            var fill = new TestTradeUpdate(TradeEvent.Fill, fillExecutionId, new TestOrder(orderId, 967, OrderSide.Sell));
+
+            var tradeUpdates = new List<TestTradeUpdate>
+            {
+                pendingNew,
+                newUpdate,
+                fill,
+                newUpdate,
+                fill,
+                newUpdate,
+                fill,
+            };
+
+            var filledCounter = 0;
+            void OnOrdersStatusChanged(object _, List<OrderEvent> oes)
+            {
+                if (oes[0].Status == OrderStatus.Filled)
+                {
+                    filledCounter += 1;
+                }
+            }
+
+            Brokerage.OrdersStatusChanged += OnOrdersStatusChanged;
+            try
+            {
+                foreach (var tradeUpdate in tradeUpdates)
+                {
+                    AlpacaBrokerage.HandleTradeUpdate(tradeUpdate);
+                }
+            }
+            finally
+            {
+                Brokerage.OrdersStatusChanged -= OnOrdersStatusChanged;
+            }
+
+            Assert.AreEqual(1, filledCounter);
+            Assert.AreEqual(0, AlpacaBrokerage._duplicationExecutionOrderIdByBrokerageOrderId.Count);
         }
     }
 }

--- a/QuantConnect.AlpacaBrokerage.Tests/Models/TestTradeUpdate.cs
+++ b/QuantConnect.AlpacaBrokerage.Tests/Models/TestTradeUpdate.cs
@@ -29,11 +29,9 @@ public record TestTradeUpdate(TradeEvent Event, Guid? ExecutionId, IOrder Order)
     public long? TradeIntegerQuantity { get; init; }
 }
 
-public record TestOrder(Guid OrderId, decimal FilledQuantity = 0) : IOrder
+public record TestOrder(Guid OrderId, decimal FilledQuantity = 0, OrderSide? OrderSide = null, AssetClass? AssetClass = AssetClass.UsEquity) : IOrder
 {
     public string Symbol { get; init; } = "AAPL";
-    public OrderSide? OrderSide { get; init; }
-    public AssetClass? AssetClass { get; init; }
     public string ClientOrderId { get; init; }
     public DateTime? CreatedAtUtc { get; init; }
     public DateTime? UpdatedAtUtc { get; init; }

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
@@ -487,6 +487,13 @@ namespace QuantConnect.Brokerages.Alpaca
                     return;
                 }
 
+                // Alpaca can replay trade updates (new/fill) after a terminal event. Once the Lean
+                // order is in a closed state, discard any further updates to avoid duplicate events.
+                if (leanOrder.Status.IsClosed())
+                {
+                    return;
+                }
+
                 switch (obj.Event)
                 {
                     case TradeEvent.New:


### PR DESCRIPTION
#### Description
Guard `HandleTradeUpdate` so that once the Lean order has reached a closed status (`Filled`/`Canceled`/`Invalid`), any further Alpaca trade updates for that order are ignored. Prevents duplicate `OrderStatus.Filled` events when Alpaca replays the `new → fill` pair with identical `execution_id`s.

#### Related PR(s)
N/A

#### Related Issue
N/A

#### Motivation and Context
Production logs showed a single `-967 TQQQ` market fill emitting three `Status: Filled` order events in Lean. Alpaca replayed the same `new` and `fill` trade updates (with identical execution_ids) three times after the first terminal event. The existing `_duplicationExecutionOrderIdByBrokerageOrderId` dedup used `Remove(orderId)` as a sentinel for `Fill`, so a replayed `new` re-created the dictionary entry and let the next replayed `fill` pass through.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- New regression test `HandleTradeUpdateShouldSkipFillDuplicationWithReplayedNew` feeds the exact replay sequence from the production log (`pending_new → new → fill → new(dup) → fill(dup) → new(dup) → fill(dup)`, duplicates reuse execution_ids) and asserts exactly one `OrderStatus.Filled` is emitted via `Brokerage.OrdersStatusChanged`.
- Existing `HandleTradeUpdate*` tests (`HandleTradeUpdateNormalCase`, `HandleTradeUpdateHandleExpiredOrder`, `HandleTradeUpdateShouldSkipDuplication`, `HandleTradeUpdateShouldSkipCanceledDuplication`, `HandleTradeUpdateShouldSkipUpdateDuplication`) still pass.

<img width="426" height="110" alt="image" src="https://github.com/user-attachments/assets/8602b827-daa7-40c6-a4d8-ba07e5be63a4" />

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention \`bug-<issue#>-<description>\` or \`feature-<issue#>-<description>\`