### PR TITLE
Update Checkout Lean Same Branch ref to actual branch name

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v2
         continue-on-error: true
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
           repository: QuantConnect/Lean
           path: Lean
 


### PR DESCRIPTION
## Description

The `Checkout Lean Same Branch` step used `ref: ${{ github.ref }}`, which resolves to a fully-qualified ref (e.g. `refs/heads/...` or `refs/pull/.../merge`) instead of a plain branch name, so the matching Lean branch is not found.

This changes it to `ref: ${{ github.head_ref || github.ref_name }}`, which resolves to the actual branch name on both `push` and `pull_request` events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)