### PR TITLE
fix: resolve renamed equity tickers in symbol mapper

### DIFF
--- a/QuantConnect.AlpacaBrokerage.Tests/AlpacaBrokerageSymbolMapperTests.cs
+++ b/QuantConnect.AlpacaBrokerage.Tests/AlpacaBrokerageSymbolMapperTests.cs
@@ -16,6 +16,7 @@
 using System;
 using Alpaca.Markets;
 using NUnit.Framework;
+using QuantConnect.Tests;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Brokerages.Alpaca.Tests
@@ -70,6 +71,28 @@ namespace QuantConnect.Brokerages.Alpaca.Tests
             var leanSymbol = GenerateLeanSymbol(symbol, securityType, optionRight, strike, expiryDate);
             var brokerageSymbol = _symbolMapper.GetBrokerageSymbol(leanSymbol);
             Assert.That(brokerageSymbol, Is.EqualTo(expectedBrokerageSymbol));
+        }
+
+        // Equity tickers change over the life of a SID. A Symbol carrying the historical permtick
+        // (e.g. an order reloaded from disk) must still map to the ticker that is current today,
+        // for the equity itself and for the option root alike.
+        [TestCase("GOOCV", "GOOG", "GOOG260608C00005000", Description = "GOOCV was renamed to GOOG on 2014/04/02")]
+        [TestCase("GOOG", "GOOGL", "GOOGL260608C00005000", Description = "GOOG was renamed to GOOGL on 2014/04/02")]
+        public void ReturnsCurrentTickerAfterEquityTickerChange(string permtick, string currentTicker, string expectedOptionSymbol)
+        {
+            TestGlobals.Initialize();
+
+            var current = Symbol.Create(currentTicker, SecurityType.Equity, Market.USA);
+            var historical = new Symbol(current.ID, permtick);
+
+            Assert.AreEqual(historical, current);
+            Assert.AreNotEqual(historical.Value, current.Value);
+
+            Assert.That(_symbolMapper.GetBrokerageSymbol(historical), Is.EqualTo(currentTicker));
+            Assert.That(_symbolMapper.GetBrokerageSymbol(current), Is.EqualTo(currentTicker));
+
+            var option = Symbol.CreateOption(historical, Market.USA, OptionStyle.American, OptionRight.Call, 5m, new DateTime(2026, 6, 8));
+            Assert.That(_symbolMapper.GetBrokerageSymbol(option), Is.EqualTo(expectedOptionSymbol));
         }
 
         [TestCase("USDC/USD", "USDCUSD")]

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerageSymbolMapper.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerageSymbolMapper.cs
@@ -128,7 +128,9 @@ public class AlpacaBrokerageSymbolMapper : ISymbolMapper
     /// <inheritdoc cref="ISymbolMapper.GetBrokerageSymbol(Symbol)"/>
     public string GetBrokerageSymbol(Symbol symbol) => symbol.SecurityType switch
     {
-        SecurityType.Equity => symbol.Value,
+        // Equity tickers change over the life of a SID (e.g. GOOCV -> GOOG). Resolve the
+        // ticker that is current today, since Symbol.Value can still carry the old one.
+        SecurityType.Equity => SecurityIdentifier.Ticker(symbol, DateTime.UtcNow),
         SecurityType.Option => GenerateBrokerageOptionSymbol(symbol),
         SecurityType.Crypto => _brokerageSymbolByLeanSymbol.TryGetValue(symbol.Value, out var cryptoSymbol)
         ? cryptoSymbol 
@@ -226,6 +228,6 @@ public class AlpacaBrokerageSymbolMapper : ISymbolMapper
 
         var strikePriceString = (Convert.ToInt32(symbol.ID.StrikePrice * 1000)).ToStringInvariant("D8");
 
-        return $"{symbol.Underlying.Value}{symbol.ID.Date:yyMMdd}{symbol.ID.OptionRight.ToString()[0]}{strikePriceString}";
+        return $"{SecurityIdentifier.Ticker(symbol.Underlying, DateTime.UtcNow)}{symbol.ID.Date:yyMMdd}{symbol.ID.OptionRight.ToString()[0]}{strikePriceString}";
     }
 }


### PR DESCRIPTION
#### Description

`GetBrokerageSymbol` read the equity ticker from `Symbol.Value` and the option OSI root from `Symbol.Underlying.Value`. Equity tickers change over the life of a SID (e.g. `GOOCV -> GOOG`), and a Symbol can still carry the old ticker in `Value` — for example an order reloaded from disk, whose `Value` defaults to the SID permtick. In that case the old ticker was sent to Alpaca, which does not know it. Both paths now resolve the ticker that is current today with `SecurityIdentifier.Ticker(symbol, DateTime.UtcNow)`.

Example with a Symbol whose `Value` is the old `GOOCV` ticker (current ticker `GOOG`):

| Security | Before | After |
| --- | --- | --- |
| Equity | `GOOCV` | `GOOG` |
| Option | `GOOCV260608C00005000` | `GOOG260608C00005000` |

Crypto is not affected: it keeps the dictionary lookup built from the Alpaca asset list.

#### Related PR(s)
Same fix as [Lean.Brokerages.CharlesSchwab#95](https://github.com/QuantConnect/Lean.Brokerages.CharlesSchwab/pull/95).

#### Related Issue
N/A

#### Motivation and Context
Orders and subscriptions for a renamed equity must use the ticker the brokerage knows today, not the historical one.

#### Requires Documentation Change
No

#### How Has This Been Tested?
Added `ReturnsCurrentTickerAfterEquityTickerChange` (`GOOCV -> GOOG`, `GOOG -> GOOGL`) to `AlpacaBrokerageSymbolMapperTests`: a Symbol carrying the historical permtick maps to the current ticker, for the equity and for the option OSI root. Existing symbol mapper tests are unaffected.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
