### PR TITLE
Detect paper environment from api key PK prefix when Alpaca is only a data provider

### DIFF
--- a/QuantConnect.AlpacaBrokerage.Tests/AlpacaBrokerageAdditionalTests.cs
+++ b/QuantConnect.AlpacaBrokerage.Tests/AlpacaBrokerageAdditionalTests.cs
@@ -19,6 +19,7 @@ using Alpaca.Markets;
 using NUnit.Framework;
 using QuantConnect.Util;
 using QuantConnect.Tests;
+using QuantConnect.Packets;
 using QuantConnect.Interfaces;
 using System.Collections.Generic;
 using QuantConnect.Securities;
@@ -45,6 +46,38 @@ namespace QuantConnect.Brokerages.Alpaca.Tests
         {
             var brokerage = Composer.Instance.GetExportedValueByTypeName<IDataQueueHandler>("AlpacaBrokerage");
             Assert.IsNotNull(brokerage);
+        }
+
+        /// <summary>
+        /// Reproduces issue #72: when Alpaca is only a data provider the job carries no
+        /// "alpaca-paper-trading" setting, so <see cref="AlpacaBrokerage.SetJob"/> must detect
+        /// the paper environment from the api key's "PK" prefix. Routing the paper key to the
+        /// live endpoint would throw "request is not authorized" while initializing, since the
+        /// symbol mapper eagerly queries the trading api.
+        /// </summary>
+        [Test]
+        public void DetectsPaperEnvironmentFromKeyPrefixWhenOnlyDataProvider()
+        {
+            var (apiKey, apiKeySecret, _, _) = AlpacaBrokerageTestHelpers.GetConfigParameters();
+            if (!apiKey.StartsWith("PK", StringComparison.Ordinal))
+            {
+                Assert.Ignore("This test requires paper api credentials, whose key starts with 'PK'.");
+            }
+
+            var job = new LiveNodePacket
+            {
+                BrokerageData = new()
+                {
+                    ["alpaca-api-key"] = apiKey,
+                    ["alpaca-api-secret"] = apiKeySecret
+                }
+            };
+
+            using var brokerage = new AlpacaBrokerage();
+            Assert.DoesNotThrow(() => brokerage.SetJob(job));
+            Assert.IsTrue(brokerage.IsConnected);
+
+            brokerage.Disconnect();
         }
 
         private static IEnumerable<Symbol> QuoteSymbolParameters

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.DataQueueHandler.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.DataQueueHandler.cs
@@ -15,6 +15,7 @@
 
 using System;
 using QuantConnect.Data;
+using QuantConnect.Logging;
 using QuantConnect.Packets;
 using QuantConnect.Interfaces;
 using System.Collections.Generic;
@@ -65,11 +66,16 @@ public partial class AlpacaBrokerage : IDataQueueHandler
         // required for trading
         job.BrokerageData.TryGetValue("alpaca-access-token", out var accessToken);
 
-        var usePaperTrading = false;
-        // might not be there if only used as a data source
-        if (job.BrokerageData.TryGetValue("alpaca-paper-trading", out var usePaper))
+        // paper api keys start with "PK"; OAuth access tokens authenticate against both environments
+        var usePaperTrading = apiKey?.StartsWith("PK", StringComparison.Ordinal) == true;
+        // might not be there if only used as a data source, or unset, arriving as an empty string locally
+        if (job.BrokerageData.TryGetValue("alpaca-paper-trading", out var usePaper) && bool.TryParse(usePaper, out var usePaperSetting))
         {
-            usePaperTrading = Convert.ToBoolean(usePaper);
+            if (usePaperTrading != usePaperSetting)
+            {
+                Log.Trace($"AlpacaBrokerage.SetJob(): \"alpaca-paper-trading\"={usePaperSetting} overrides the environment detected from the api key");
+            }
+            usePaperTrading = usePaperSetting;
         }
 
         Initialize(apiKey, secretKey, accessToken, usePaperTrading, null, null);


### PR DESCRIPTION
## Description

Fixes #72. When Alpaca is used only as a secondary data provider, the Live Deployment Wizard exposes no Paper/Live selector, so `alpaca-paper-trading` never reaches `job.BrokerageData` and `SetJob` defaulted every client to the live endpoint — which rejects paper credentials with `request is not authorized`.

`SetJob` now derives the default environment from the API key itself: paper keys are detected by their `PK` prefix. An explicit parseable `alpaca-paper-trading` value still takes precedence, so existing deployments that set the flag behave exactly as before (a trace log records when the setting overrides the detection). Unset, empty, or invalid values fall back to the detection via `bool.TryParse` — locally the job packet always carries the key (as an empty string when unconfigured), which previously would have thrown `FormatException` in `Convert.ToBoolean`.

OAuth-only deployments are unaffected: access tokens carry no environment prefix and authenticate against both trading endpoints, and the market-data endpoints are environment-independent.

## Source of the `PK` prefix

The prefix is a convention used by Alpaca's own tooling rather than a documented contract: Alpaca's [example-hftish](https://github.com/alpacahq/example-hftish/blob/master/tick_taker.py) selects `paper-api.alpaca.markets` via `key_id.startswith('PK')`, and the official [Alpaca CLI](https://github.com/alpacahq/cli) uses `ALPACA_API_KEY=PK...` throughout its paper examples. Verified empirically: a paper key returns 200 on `paper-api.alpaca.markets/v2/account` and 401 on `api.alpaca.markets`. Because the prefix is undocumented, the explicit setting keeps precedence.

## Testing

- New `DetectsPaperEnvironmentFromKeyPrefixWhenOnlyDataProvider` test in `AlpacaBrokerageAdditionalTests`: `SetJob` with a paper key and no `alpaca-paper-trading` initializes and connects — routing the paper key to the live endpoint would throw `request is not authorized` during the symbol mapper's eager trading-API call, so success asserts the routing. Passed against the paper endpoint.
- End-to-end local deployment reproducing the issue: `PaperBrokerage` as the brokerage + Alpaca as data-queue-handler only, paper key, no environment setting — SPY streamed via IEX and `BasicTemplateAlgorithm` traded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
