### PR TITLE
feature: support one-cancels-the-other orders

### DIFF
--- a/QuantConnect.AlpacaBrokerage.Tests/AlpacaBrokerageOneCancelsTheOtherOrderTests.cs
+++ b/QuantConnect.AlpacaBrokerage.Tests/AlpacaBrokerageOneCancelsTheOtherOrderTests.cs
@@ -1,0 +1,60 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using Moq;
+using NUnit.Framework;
+using QuantConnect.Tests;
+using QuantConnect.Orders;
+using AlpacaMarket = Alpaca.Markets;
+using System.Collections.Generic;
+
+namespace QuantConnect.Brokerages.Alpaca.Tests
+{
+    /// <summary>
+    /// Pure unit tests for the one-cancels-the-other (OCO) group validation and request construction. These do
+    /// not construct an <see cref="AlpacaBrokerage"/> instance and do not require live/paper trading credentials.
+    /// </summary>
+    [TestFixture]
+    public class AlpacaBrokerageOneCancelsTheOtherOrderTests
+    {
+        private static readonly DateTime OrderTime = new(2026, 1, 1);
+
+        [TestCase(-100, "sell")]
+        [TestCase(100, "buy")]
+        public void CreateAlpacaOneCancelsTheOtherOrderBuildsExpectedRequest(decimal quantitySign, string expectedSide)
+        {
+            var tradingClientMock = new Mock<AlpacaMarket.IAlpacaTradingClient>();
+            tradingClientMock
+                .Setup(m => m.ListAssetsAsync(It.IsAny<AlpacaMarket.AssetsRequest>(), It.IsAny<System.Threading.CancellationToken>()))
+                .ReturnsAsync(new List<AlpacaMarket.IAsset>());
+            var symbolMapper = new AlpacaBrokerageSymbolMapper(tradingClientMock.Object);
+            var orders = new List<Order>
+            {
+                new LimitOrder(Symbols.AAPL, quantitySign, 220m, OrderTime),
+                new StopMarketOrder(Symbols.AAPL, quantitySign, 190m, OrderTime)
+            };
+
+            var ocoOrder = orders.CreateAlpacaOneCancelsTheOtherOrder(symbolMapper);
+
+            Assert.AreEqual(AlpacaMarket.OrderClass.OneCancelsOther, ocoOrder.OrderClass);
+            Assert.AreEqual(220m, ocoOrder.TakeProfit.LimitPrice);
+            Assert.AreEqual(190m, ocoOrder.StopLoss.StopPrice);
+            Assert.IsNull(ocoOrder.StopLoss.LimitPrice);
+            Assert.AreEqual(expectedSide, ocoOrder.Side.ToString().ToLowerInvariant());
+            Assert.AreEqual("AAPL", ocoOrder.Symbol);
+        }
+    }
+}

--- a/QuantConnect.AlpacaBrokerage.Tests/AlpacaBrokerageOneCancelsTheOtherOrderTests.cs
+++ b/QuantConnect.AlpacaBrokerage.Tests/AlpacaBrokerageOneCancelsTheOtherOrderTests.cs
@@ -41,13 +41,10 @@ namespace QuantConnect.Brokerages.Alpaca.Tests
                 .Setup(m => m.ListAssetsAsync(It.IsAny<AlpacaMarket.AssetsRequest>(), It.IsAny<System.Threading.CancellationToken>()))
                 .ReturnsAsync(new List<AlpacaMarket.IAsset>());
             var symbolMapper = new AlpacaBrokerageSymbolMapper(tradingClientMock.Object);
-            var orders = new List<Order>
-            {
-                new LimitOrder(Symbols.AAPL, quantitySign, 220m, OrderTime),
-                new StopMarketOrder(Symbols.AAPL, quantitySign, 190m, OrderTime)
-            };
+            var limitLeg = new LimitOrder(Symbols.AAPL, quantitySign, 220m, OrderTime);
+            var stopLeg = new StopMarketOrder(Symbols.AAPL, quantitySign, 190m, OrderTime);
 
-            var ocoOrder = orders.CreateAlpacaOneCancelsTheOtherOrder(symbolMapper);
+            var ocoOrder = limitLeg.CreateAlpacaOneCancelsTheOtherOrder(stopLeg, symbolMapper);
 
             Assert.AreEqual(AlpacaMarket.OrderClass.OneCancelsOther, ocoOrder.OrderClass);
             Assert.AreEqual(220m, ocoOrder.TakeProfit.LimitPrice);

--- a/QuantConnect.AlpacaBrokerage.Tests/AlpacaBrokerageOneCancelsTheOtherTests.cs
+++ b/QuantConnect.AlpacaBrokerage.Tests/AlpacaBrokerageOneCancelsTheOtherTests.cs
@@ -1,0 +1,239 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using QuantConnect.Logging;
+using QuantConnect.Orders;
+using QuantConnect.Tests;
+using QuantConnect.Tests.Brokerages;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using TradeEvent = Alpaca.Markets.TradeEvent;
+using QuantConnect.Brokerages.Alpaca.Tests.Models;
+
+namespace QuantConnect.Brokerages.Alpaca.Tests
+{
+    // Alpaca's OCO is exit-only, so every scenario below opens a long
+    // position first, then submits the 2-leg exit group the same way
+    // QCAlgorithm.OneCancelsTheOtherOrder/SubmitGroupOrder would: two plain orders sharing one
+    // GroupOrderManager with ComboType.OneCancelsTheOther, built directly (there is no live
+    // QCAlgorithm in this test fixture to call the public API through).
+    public partial class AlpacaBrokerageTests
+    {
+        [Test]
+        public void OneCancelsTheOtherOrderTakeProfitLegFillsAndCancelsStopLossLeg()
+        {
+            Log.Trace("");
+            Log.Trace("ONE-CANCELS-THE-OTHER: TAKE PROFIT LEG WINS");
+            Log.Trace("");
+
+            PlaceOrderWaitForStatus(new MarketOrderTestParameters(Symbol).CreateLongOrder(GetDefaultQuantity()), OrderStatus.Filled);
+
+            var currentPrice = GetAskPrice(Symbol);
+            // a sell limit priced below the current ask crosses the spread and should fill almost
+            // immediately; the stop is priced far away so it can never trigger during the test
+            var takeProfitLimitPrice = Math.Round(currentPrice * 0.98m, 2);
+            var stopLossStopPrice = Math.Round(currentPrice * 0.5m, 2);
+
+            var orders = CreateOneCancelsTheOtherOrders(-GetDefaultQuantity(), takeProfitLimitPrice, stopLossStopPrice);
+            PlaceOrderWaitForStatus(orders, OrderStatus.Submitted);
+            AssertEachLegGotItsOwnBrokerId(orders);
+
+            WaitForOneCancelsTheOtherResolution(orders);
+
+            Assert.AreEqual(OrderStatus.Filled, orders.Single(o => o.Type == OrderType.Limit).Status);
+            Assert.AreEqual(OrderStatus.Canceled, orders.Single(o => o.Type == OrderType.StopMarket).Status);
+        }
+
+        [Test]
+        public void OneCancelsTheOtherOrderStopLossLegFillsAndCancelsTakeProfitLeg()
+        {
+            Log.Trace("");
+            Log.Trace("ONE-CANCELS-THE-OTHER: STOP LOSS LEG WINS");
+            Log.Trace("");
+
+            PlaceOrderWaitForStatus(new MarketOrderTestParameters(Symbol).CreateLongOrder(GetDefaultQuantity()), OrderStatus.Filled);
+
+            var currentPrice = GetAskPrice(Symbol);
+            // a sell stop priced above the current price is already triggered and should fill almost
+            // immediately; the limit is priced far away so it can never become marketable during the test
+            var takeProfitLimitPrice = Math.Round(currentPrice * 1.5m, 2);
+            var stopLossStopPrice = Math.Round(currentPrice * 1.02m, 2);
+
+            var orders = CreateOneCancelsTheOtherOrders(-GetDefaultQuantity(), takeProfitLimitPrice, stopLossStopPrice);
+            PlaceOrderWaitForStatus(orders, OrderStatus.Submitted);
+            AssertEachLegGotItsOwnBrokerId(orders);
+
+            WaitForOneCancelsTheOtherResolution(orders);
+
+            Assert.AreEqual(OrderStatus.Canceled, orders.Single(o => o.Type == OrderType.Limit).Status);
+            Assert.AreEqual(OrderStatus.Filled, orders.Single(o => o.Type == OrderType.StopMarket).Status);
+        }
+
+        [Test]
+        public void OneCancelsTheOtherOrderCancelingOneLegCancelsWholeGroup()
+        {
+            Log.Trace("");
+            Log.Trace("ONE-CANCELS-THE-OTHER: CANCELING ONE LEG CANCELS THE WHOLE GROUP");
+            Log.Trace("");
+
+             PlaceOrderWaitForStatus(new MarketOrderTestParameters(Symbol).CreateLongOrder(GetDefaultQuantity()), OrderStatus.Filled);
+
+            var currentPrice = GetAskPrice(Symbol);
+            // both legs are priced far away from the market so neither can fill before we cancel one of them
+            var takeProfitLimitPrice = Math.Round(currentPrice * 1.5m, 2);
+            var stopLossStopPrice = Math.Round(currentPrice * 0.5m, 2);
+
+            var orders = CreateOneCancelsTheOtherOrders(-GetDefaultQuantity(), takeProfitLimitPrice, stopLossStopPrice);
+            PlaceOrderWaitForStatus(orders, OrderStatus.Submitted);
+            AssertEachLegGotItsOwnBrokerId(orders);
+
+            using var bothCanceledEvent = new ManualResetEvent(false);
+            EventHandler<List<OrderEvent>> handler = (_, __) =>
+            {
+                if (orders.All(o => o.Status == OrderStatus.Canceled))
+                {
+                    try { bothCanceledEvent.Set(); } catch (ObjectDisposedException) { }
+                }
+            };
+
+            Brokerage.OrdersStatusChanged += handler;
+            try
+            {
+                Assert.IsTrue(Brokerage.CancelOrder(orders.First()));
+                bothCanceledEvent.WaitOneAssertFail(30000, "Expected both one-cancels-the-other legs to end up Canceled after canceling one of them." +
+                    string.Join("", orders.Select(o => $" Order Id:{o.Id} Status:{o.Status}")));
+            }
+            finally
+            {
+                Brokerage.OrdersStatusChanged -= handler;
+            }
+        }
+
+        [Test]
+        public void HandleTradeUpdateEmitsCanceledForHeldLegWithNoPriorNewEvent()
+        {
+            // Regression test for a live-testing bug: the passive/held leg of a one-cancels-the-other group
+            // never receives its own New/PendingNew event - Alpaca reports "held" instead, straight to
+            // "canceled" once the other leg wins. Held used to be a pure no-op that did not register the
+            // order in _duplicationExecutionOrderIdByBrokerageOrderId, so the later genuine Canceled event
+            // found nothing to Remove(), was mistaken for an unregistered replay, and was silently dropped -
+            // both legs stayed stuck at Submitted forever.
+            var orderId = Guid.NewGuid();
+
+            var order = new StopMarketOrder(Symbols.AAPL, -1m, 190m, default);
+            order.BrokerId.Add(orderId.ToString());
+            OrderProvider.Add(order);
+
+            var held = new TestTradeUpdate(TradeEvent.Held, null, new TestOrder(orderId));
+            var canceled = new TestTradeUpdate(TradeEvent.Canceled, null, new TestOrder(orderId));
+
+            AlpacaBrokerage.HandleTradeUpdate(held);
+            Assert.AreNotEqual(OrderStatus.Canceled, order.Status, "Held itself should not change the order's status.");
+
+            var canceledEventReceived = false;
+            EventHandler<List<OrderEvent>> handler = (_, orderEvents) =>
+            {
+                if (orderEvents[0].Status == OrderStatus.Canceled)
+                {
+                    canceledEventReceived = true;
+                }
+            };
+
+            Brokerage.OrdersStatusChanged += handler;
+            try
+            {
+                AlpacaBrokerage.HandleTradeUpdate(canceled);
+            }
+            finally
+            {
+                Brokerage.OrdersStatusChanged -= handler;
+            }
+
+            Assert.IsTrue(canceledEventReceived, "Expected a Canceled OrderEvent even though the order never received a New/PendingNew event first.");
+        }
+
+        /// <summary>
+        /// Builds a plain 2-leg one-cancels-the-other group (one Limit take-profit leg, one StopMarket stop-loss
+        /// leg) sharing one <see cref="GroupOrderManager"/>, mirroring what
+        /// QCAlgorithm.OneCancelsTheOtherOrder/SubmitGroupOrder builds internally.
+        /// </summary>
+        private List<Order> CreateOneCancelsTheOtherOrders(decimal quantity, decimal takeProfitLimitPrice, decimal stopLossStopPrice)
+        {
+            var groupOrderManager = new GroupOrderManager(2, quantity, 0) { ComboType = ComboType.OneCancelsTheOther };
+
+            var limitOrder = new LimitOrder(Symbol, quantity, takeProfitLimitPrice, DateTime.UtcNow, properties: OrderProperties)
+            {
+                GroupOrderManager = groupOrderManager,
+                Status = OrderStatus.New
+            };
+            var stopOrder = new StopMarketOrder(Symbol, quantity, stopLossStopPrice, DateTime.UtcNow, properties: OrderProperties)
+            {
+                GroupOrderManager = groupOrderManager,
+                Status = OrderStatus.New
+            };
+
+            return new List<Order> { limitOrder, stopOrder };
+        }
+
+        /// <summary>
+        /// Waits until one leg of the group reaches Filled and the other reaches Canceled. Unlike
+        /// <see cref="BrokerageTests.PlaceOrderWaitForStatus"/>, the two legs are expected to end up in
+        /// different terminal statuses, so a single shared expected status cannot be used here.
+        /// </summary>
+        private void WaitForOneCancelsTheOtherResolution(IReadOnlyCollection<Order> orders, double secondsTimeout = 30.0)
+        {
+            bool IsResolved() => orders.Any(o => o.Status == OrderStatus.Filled) && orders.Any(o => o.Status == OrderStatus.Canceled);
+
+            using var resolvedEvent = new ManualResetEvent(false);
+            EventHandler<List<OrderEvent>> handler = (_, __) =>
+            {
+                if (IsResolved())
+                {
+                    try { resolvedEvent.Set(); } catch (ObjectDisposedException) { }
+                }
+            };
+
+            Brokerage.OrdersStatusChanged += handler;
+            try
+            {
+                if (!IsResolved())
+                {
+                    resolvedEvent.WaitOneAssertFail(Convert.ToInt32(1000 * secondsTimeout),
+                        "Expected one leg of the one-cancels-the-other group to fill and the other to be canceled." +
+                        string.Join("", orders.Select(o => $" Order Id:{o.Id} Status:{o.Status}")));
+                }
+            }
+            finally
+            {
+                Brokerage.OrdersStatusChanged -= handler;
+            }
+        }
+
+        /// <summary>
+        /// Verifies that every leg of the group received its own, distinct Alpaca order id right after
+        /// submission - the parent (take-profit) id from the OCO POST response and the child (stop-loss)
+        /// id from its nested leg.
+        /// </summary>
+        private static void AssertEachLegGotItsOwnBrokerId(IReadOnlyCollection<Order> orders)
+        {
+            Assert.IsTrue(orders.All(o => o.BrokerId.Count > 0), "Expected every one-cancels-the-other leg to receive its own Alpaca order id.");
+            Assert.AreEqual(orders.Count, orders.Select(o => o.BrokerId.Single()).Distinct().Count(),
+                "Expected each one-cancels-the-other leg to receive a distinct Alpaca order id.");
+        }
+    }
+}

--- a/QuantConnect.AlpacaBrokerage.Tests/AlpacaBrokerageOneCancelsTheOtherTests.cs
+++ b/QuantConnect.AlpacaBrokerage.Tests/AlpacaBrokerageOneCancelsTheOtherTests.cs
@@ -30,7 +30,7 @@ namespace QuantConnect.Brokerages.Alpaca.Tests
     // Alpaca's OCO is exit-only, so every scenario below opens a long
     // position first, then submits the 2-leg exit group the same way
     // QCAlgorithm.OneCancelsTheOtherOrder/SubmitGroupOrder would: two plain orders sharing one
-    // GroupOrderManager with ComboType.OneCancelsTheOther, built directly (there is no live
+    // GroupOrderManager with GroupExecutionType.OneCancelsTheOther, built directly (there is no live
     // QCAlgorithm in this test fixture to call the public API through).
     public partial class AlpacaBrokerageTests
     {
@@ -174,7 +174,7 @@ namespace QuantConnect.Brokerages.Alpaca.Tests
         /// </summary>
         private List<Order> CreateOneCancelsTheOtherOrders(decimal quantity, decimal takeProfitLimitPrice, decimal stopLossStopPrice)
         {
-            var groupOrderManager = new GroupOrderManager(2, quantity, 0) { ComboType = ComboType.OneCancelsTheOther };
+            var groupOrderManager = new GroupOrderManager(2, quantity, 0) { ExecutionType = GroupExecutionType.OneCancelsTheOther };
 
             var limitOrder = new LimitOrder(Symbol, quantity, takeProfitLimitPrice, DateTime.UtcNow, properties: OrderProperties)
             {

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
@@ -473,7 +473,7 @@ namespace QuantConnect.Brokerages.Alpaca
                 return true;
             }
 
-            if (orders.Count > 1 && order.GroupOrderManager?.ExecutionType == GroupExecutionType.OneCancelsTheOther)
+            if (order.GroupOrderManager?.ExecutionType == GroupExecutionType.OneCancelsTheOther)
             {
                 PlaceOneCancelsTheOtherOrder(orders);
                 return true;
@@ -508,16 +508,13 @@ namespace QuantConnect.Brokerages.Alpaca
         }
 
         /// <summary>
-        /// Places a Lean one-cancels-the-other (OCO) group as a single Alpaca OCO order: the take-profit limit
-        /// leg becomes the parent order and the stop-loss leg becomes its nested stop_loss leg. Both legs receive
-        /// their own real Alpaca order id before the stream lock releases, so later trade updates for either leg
-        /// route to the right Lean order instead of being adopted as an order placed outside Lean.
+        /// Places a Lean one-cancels-the-other (OCO) group as one Alpaca OCO order: the limit leg becomes the
+        /// parent take profit order and the stop leg becomes its nested stop loss leg
         /// </summary>
         /// <param name="orders">The group's legs, as resolved by <see cref="_groupOrderCacheManager"/></param>
         private void PlaceOneCancelsTheOtherOrder(List<Order> orders)
         {
-            // Alpaca's constraints on these groups are checked per leg in AlpacaBrokerageModel.CanSubmitOrder,
-            // so a group only reaches this point with 2 same-side equity legs of the right order types
+            // AlpacaBrokerageModel.CanSubmitOrder checks every leg, so the group is 2 equity legs on one side here
             var limitLeg = (Orders.LimitOrder)orders.Single(o => o.Type == Orders.OrderType.Limit);
             var stopLeg = (StopMarketOrder)orders.Single(o => o.Type == Orders.OrderType.StopMarket);
 
@@ -525,20 +522,20 @@ namespace QuantConnect.Brokerages.Alpaca
             {
                 ExecuteWhenReconnectedAndStreamLocked(nameof(PlaceOrder), () =>
                 {
-                    var ocoOrder = orders.CreateAlpacaOneCancelsTheOtherOrder(_symbolMapper);
+                    var ocoOrder = limitLeg.CreateAlpacaOneCancelsTheOtherOrder(stopLeg, _symbolMapper);
                     var response = _tradingClient.PostOrderAsync(ocoOrder).SynchronouslyAwaitTaskResult();
                     if (response == null || response.OrderStatus == AlpacaMarket.OrderStatus.Rejected)
                     {
-                        OnOrderEvents(orders.ToList(o => new OrderEvent(o, DateTime.UtcNow, OrderFee.Zero, $"Place One-Cancels-the-Other (OCO) Failed")
-                        { 
+                        OnOrderEvents(orders.ToList(o => new OrderEvent(o, DateTime.UtcNow, OrderFee.Zero, $"{nameof(AlpacaBrokerage)} Place One-Cancels-the-Other Order Failed")
+                        {
                             Status = Orders.OrderStatus.Invalid
                         }));
                         return;
                     }
 
-                    // the response is the take-profit (parent) order; its one child leg is the stop-loss order.
-                    // The child id is commonly observed in the POST response, but that is not clearly documented,
-                    // so fall back to a single GET by id if it is ever missing
+                    // the response is the parent take profit order and its one leg is the stop loss. The leg id is
+                    // there in practice but not documented, so read the order back once when it is missing. Both ids
+                    // must be set before the lock releases, or the first stream event looks like an outside order
                     limitLeg.BrokerId.Add(response.OrderId.ToString());
                     var childOrderId = response.Legs.SingleOrDefault()?.OrderId;
                     if (!childOrderId.HasValue)
@@ -548,8 +545,8 @@ namespace QuantConnect.Brokerages.Alpaca
                     }
                     stopLeg.BrokerId.Add(childOrderId.Value.ToString());
 
-                    OnOrderEvents(orders.ToList(o => new OrderEvent(o, DateTime.UtcNow, OrderFee.Zero, $"Place One-Cancels-the-Other (OCO)")
-                    { 
+                    OnOrderEvents(orders.ToList(o => new OrderEvent(o, DateTime.UtcNow, OrderFee.Zero, $"{nameof(AlpacaBrokerage)} Order Event")
+                    {
                         Status = Orders.OrderStatus.Submitted
                     }));
                 });
@@ -564,9 +561,9 @@ namespace QuantConnect.Brokerages.Alpaca
         }
 
         /// <summary>
-        /// Emits a warning if a sibling leg of the same one-cancels-the-other group already filled. Alpaca
-        /// documents that "in extremely volatile and fast market conditions, both orders may fill before the
-        /// cancellation occurs" - this cannot be prevented client-side, only surfaced to the algorithm.
+        /// Warns when both legs of a one-cancels-the-other group filled. Alpaca documents that "in extremely
+        /// volatile and fast market conditions, both orders may fill before the cancellation occurs", which the
+        /// client cannot prevent, only report
         /// </summary>
         /// <param name="leanOrder">The order that just filled</param>
         private void WarnIfOneCancelsTheOtherSiblingAlreadyFilled(Order leanOrder)
@@ -644,11 +641,9 @@ namespace QuantConnect.Brokerages.Alpaca
                     case TradeEvent.New:
                     case TradeEvent.PendingNew:
                     case TradeEvent.Held:
-                        // we don't send anything for this event. Held is reported for the passive leg of a
-                        // one-cancels-the-other group while it waits, per community reports - and unlike a
-                        // normal leg, it never gets its own New/PendingNew event first, so it must be
-                        // registered here too or its eventual terminal event below would find nothing to
-                        // Remove() and get mistaken for an unregistered replay and silently dropped
+                        // we don't send anything for this event. The waiting leg of a one-cancels-the-other group
+                        // reports Held and never gets a New event first, so it has to register here as well or its
+                        // later fill or cancel finds nothing to Remove() and is dropped as an unknown order
                         _duplicationExecutionOrderIdByBrokerageOrderId.TryAdd(obj.Order.OrderId, []);
                         return;
                     case TradeEvent.Rejected:

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
@@ -473,7 +473,7 @@ namespace QuantConnect.Brokerages.Alpaca
                 return true;
             }
 
-            if (orders.Count > 1 && order.GroupOrderManager?.ComboType == ComboType.OneCancelsTheOther)
+            if (orders.Count > 1 && order.GroupOrderManager?.ExecutionType == GroupExecutionType.OneCancelsTheOther)
             {
                 PlaceOneCancelsTheOtherOrder(orders);
                 return true;
@@ -572,7 +572,7 @@ namespace QuantConnect.Brokerages.Alpaca
         private void WarnIfOneCancelsTheOtherSiblingAlreadyFilled(Order leanOrder)
         {
             var groupOrderManager = leanOrder.GroupOrderManager;
-            if (groupOrderManager == null || groupOrderManager.ComboType != ComboType.OneCancelsTheOther)
+            if (groupOrderManager == null || groupOrderManager.ExecutionType != GroupExecutionType.OneCancelsTheOther)
             {
                 return;
             }

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerage.cs
@@ -60,6 +60,11 @@ namespace QuantConnect.Brokerages.Alpaca
         private BrokerageConcurrentMessageHandler<ITradeUpdate> _messageHandler;
         private AlpacaBrokerageSymbolMapper _symbolMapper;
 
+        /// <summary>
+        /// Caches group/combo order legs until all of them arrive before submitting a single brokerage order.
+        /// </summary>
+        private readonly GroupOrderCacheManager _groupOrderCacheManager = new();
+
         private IAlpacaTradingClient _tradingClient;
 
         private IAlpacaDataClient _equityHistoricalDataClient;
@@ -462,6 +467,18 @@ namespace QuantConnect.Brokerages.Alpaca
                 return false;
             }
 
+            if (!_groupOrderCacheManager.TryGetGroupCachedOrders(order, out var orders))
+            {
+                // not every leg of the group has arrived yet; wait for the rest
+                return true;
+            }
+
+            if (orders.Count > 1 && order.GroupOrderManager?.ComboType == ComboType.OneCancelsTheOther)
+            {
+                PlaceOneCancelsTheOtherOrder(orders);
+                return true;
+            }
+
             try
             {
                 ExecuteWhenReconnectedAndStreamLocked(nameof(PlaceOrder), () =>
@@ -488,6 +505,93 @@ namespace QuantConnect.Brokerages.Alpaca
                 OnOrderEvent(new OrderEvent(order, DateTime.UtcNow, OrderFee.Zero, ex.Message) { Status = Orders.OrderStatus.Invalid });
             }
             return true;
+        }
+
+        /// <summary>
+        /// Places a Lean one-cancels-the-other (OCO) group as a single Alpaca OCO order: the take-profit limit
+        /// leg becomes the parent order and the stop-loss leg becomes its nested stop_loss leg. Both legs receive
+        /// their own real Alpaca order id before the stream lock releases, so later trade updates for either leg
+        /// route to the right Lean order instead of being adopted as an order placed outside Lean.
+        /// </summary>
+        /// <param name="orders">The group's legs, as resolved by <see cref="_groupOrderCacheManager"/></param>
+        private void PlaceOneCancelsTheOtherOrder(List<Order> orders)
+        {
+            // Alpaca's constraints on these groups are checked per leg in AlpacaBrokerageModel.CanSubmitOrder,
+            // so a group only reaches this point with 2 same-side equity legs of the right order types
+            var limitLeg = (Orders.LimitOrder)orders.Single(o => o.Type == Orders.OrderType.Limit);
+            var stopLeg = (StopMarketOrder)orders.Single(o => o.Type == Orders.OrderType.StopMarket);
+
+            try
+            {
+                ExecuteWhenReconnectedAndStreamLocked(nameof(PlaceOrder), () =>
+                {
+                    var ocoOrder = orders.CreateAlpacaOneCancelsTheOtherOrder(_symbolMapper);
+                    var response = _tradingClient.PostOrderAsync(ocoOrder).SynchronouslyAwaitTaskResult();
+                    if (response == null || response.OrderStatus == AlpacaMarket.OrderStatus.Rejected)
+                    {
+                        OnOrderEvents(orders.ToList(o => new OrderEvent(o, DateTime.UtcNow, OrderFee.Zero, $"Place One-Cancels-the-Other (OCO) Failed")
+                        { 
+                            Status = Orders.OrderStatus.Invalid
+                        }));
+                        return;
+                    }
+
+                    // the response is the take-profit (parent) order; its one child leg is the stop-loss order.
+                    // The child id is commonly observed in the POST response, but that is not clearly documented,
+                    // so fall back to a single GET by id if it is ever missing
+                    limitLeg.BrokerId.Add(response.OrderId.ToString());
+                    var childOrderId = response.Legs.SingleOrDefault()?.OrderId;
+                    if (!childOrderId.HasValue)
+                    {
+                        var fullOrder = _tradingClient.GetOrderAsync(response.OrderId).SynchronouslyAwaitTaskResult();
+                        childOrderId = fullOrder.Legs.Single().OrderId;
+                    }
+                    stopLeg.BrokerId.Add(childOrderId.Value.ToString());
+
+                    OnOrderEvents(orders.ToList(o => new OrderEvent(o, DateTime.UtcNow, OrderFee.Zero, $"Place One-Cancels-the-Other (OCO)")
+                    { 
+                        Status = Orders.OrderStatus.Submitted
+                    }));
+                });
+            }
+            catch (Exception ex)
+            {
+                OnOrderEvents(orders.ToList(o => new OrderEvent(o, DateTime.UtcNow, OrderFee.Zero, ex.Message)
+                {
+                    Status = Orders.OrderStatus.Invalid
+                }));
+            }
+        }
+
+        /// <summary>
+        /// Emits a warning if a sibling leg of the same one-cancels-the-other group already filled. Alpaca
+        /// documents that "in extremely volatile and fast market conditions, both orders may fill before the
+        /// cancellation occurs" - this cannot be prevented client-side, only surfaced to the algorithm.
+        /// </summary>
+        /// <param name="leanOrder">The order that just filled</param>
+        private void WarnIfOneCancelsTheOtherSiblingAlreadyFilled(Order leanOrder)
+        {
+            var groupOrderManager = leanOrder.GroupOrderManager;
+            if (groupOrderManager == null || groupOrderManager.ComboType != ComboType.OneCancelsTheOther)
+            {
+                return;
+            }
+
+            foreach (var siblingOrderId in groupOrderManager.OrderIds)
+            {
+                if (siblingOrderId == leanOrder.Id)
+                {
+                    continue;
+                }
+
+                if (_orderProvider.GetOrderById(siblingOrderId)?.Status == Orders.OrderStatus.Filled)
+                {
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "OneCancelsTheOtherDoubleFill",
+                        $"Both legs of one-cancels-the-other group {groupOrderManager.Id} filled (orders {leanOrder.Id} and {siblingOrderId}). " +
+                        "Alpaca documents this as possible in extremely volatile and fast market conditions."));
+                    return;
+                }
+            }
         }
 
         internal void HandleTradeUpdate(ITradeUpdate obj)
@@ -539,7 +643,12 @@ namespace QuantConnect.Brokerages.Alpaca
                 {
                     case TradeEvent.New:
                     case TradeEvent.PendingNew:
-                        // we don't send anything for this event
+                    case TradeEvent.Held:
+                        // we don't send anything for this event. Held is reported for the passive leg of a
+                        // one-cancels-the-other group while it waits, per community reports - and unlike a
+                        // normal leg, it never gets its own New/PendingNew event first, so it must be
+                        // registered here too or its eventual terminal event below would find nothing to
+                        // Remove() and get mistaken for an unregistered replay and silently dropped
                         _duplicationExecutionOrderIdByBrokerageOrderId.TryAdd(obj.Order.OrderId, []);
                         return;
                     case TradeEvent.Rejected:
@@ -608,6 +717,8 @@ namespace QuantConnect.Brokerages.Alpaca
                 {
                     var security = _securityProvider.GetSecurity(leanOrder.Symbol);
                     fee = security.FeeModel.GetOrderFee(new OrderFeeParameters(security, leanOrder));
+
+                    WarnIfOneCancelsTheOtherSiblingAlreadyFilled(leanOrder);
                 }
 
                 var orderEvent = new OrderEvent(leanOrder, obj.TimestampUtc.HasValue ? obj.TimestampUtc.Value : DateTime.UtcNow, fee)

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerageExtensions.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerageExtensions.cs
@@ -14,9 +14,11 @@
 */
 
 using System;
+using System.Linq;
 using QuantConnect.Orders;
 using QuantConnect.Logging;
 using AlpacaMarket = Alpaca.Markets;
+using System.Collections.Generic;
 using QuantConnect.Orders.TimeInForces;
 
 using static Alpaca.Markets.OrderBaseExtensions;
@@ -25,6 +27,31 @@ namespace QuantConnect.Brokerages.Alpaca;
 
 public static class AlpacaBrokerageExtensions
 {
+    /// <summary>
+    /// Creates an Alpaca one-cancels-the-other (OCO) order from a validated 2-leg Lean OCO group: the
+    /// take-profit limit leg becomes the parent order and the stop-loss leg becomes its nested stop_loss leg.
+    /// The caller is expected to have already validated the group (2 legs, same symbol, same side, one Limit
+    /// and one StopMarket leg) before calling this method.
+    /// </summary>
+    /// <param name="orders">The 2-leg OCO group: one <see cref="LimitOrder"/> (take-profit) and one <see cref="StopMarketOrder"/> (stop-loss)</param>
+    /// <param name="symbolMapper">The symbol mapper used to convert the Lean symbol into the brokerage symbol</param>
+    /// <returns>The Alpaca <see cref="AlpacaMarket.OneCancelsOtherOrder"/> ready to submit</returns>
+    public static AlpacaMarket.OneCancelsOtherOrder CreateAlpacaOneCancelsTheOtherOrder(this List<Order> orders, ISymbolMapper symbolMapper)
+    {
+        var limitLeg = (LimitOrder)orders.Single(o => o.Type == OrderType.Limit);
+        var stopLeg = (StopMarketOrder)orders.Single(o => o.Type == OrderType.StopMarket);
+
+        var brokerageSymbol = symbolMapper.GetBrokerageSymbol(limitLeg.Symbol);
+        var quantity = AlpacaMarket.OrderQuantity.Fractional(limitLeg.AbsoluteQuantity);
+
+        var takeProfitLeg = limitLeg.Direction == OrderDirection.Buy
+            ? AlpacaMarket.LimitOrder.Buy(brokerageSymbol, quantity, limitLeg.LimitPrice)
+            : AlpacaMarket.LimitOrder.Sell(brokerageSymbol, quantity, limitLeg.LimitPrice);
+
+        return takeProfitLeg.OneCancelsOther(stopLeg.StopPrice)
+            .WithDuration(limitLeg.TimeInForce.ConvertLeanTimeInForceToBrokerage(limitLeg.SecurityType, limitLeg.Type));
+    }
+
     /// <summary>
     /// Creates an Alpaca sell order based on the provided Lean order type.
     /// </summary>

--- a/QuantConnect.AlpacaBrokerage/AlpacaBrokerageExtensions.cs
+++ b/QuantConnect.AlpacaBrokerage/AlpacaBrokerageExtensions.cs
@@ -14,11 +14,9 @@
 */
 
 using System;
-using System.Linq;
 using QuantConnect.Orders;
 using QuantConnect.Logging;
 using AlpacaMarket = Alpaca.Markets;
-using System.Collections.Generic;
 using QuantConnect.Orders.TimeInForces;
 
 using static Alpaca.Markets.OrderBaseExtensions;
@@ -28,19 +26,16 @@ namespace QuantConnect.Brokerages.Alpaca;
 public static class AlpacaBrokerageExtensions
 {
     /// <summary>
-    /// Creates an Alpaca one-cancels-the-other (OCO) order from a validated 2-leg Lean OCO group: the
-    /// take-profit limit leg becomes the parent order and the stop-loss leg becomes its nested stop_loss leg.
-    /// The caller is expected to have already validated the group (2 legs, same symbol, same side, one Limit
-    /// and one StopMarket leg) before calling this method.
+    /// Creates an Alpaca one-cancels-the-other (OCO) order: the limit leg becomes the parent take profit order
+    /// and the stop leg becomes its nested stop_loss leg. Both legs must be on the same symbol and the same side
     /// </summary>
-    /// <param name="orders">The 2-leg OCO group: one <see cref="LimitOrder"/> (take-profit) and one <see cref="StopMarketOrder"/> (stop-loss)</param>
+    /// <param name="limitLeg">The take profit leg</param>
+    /// <param name="stopLeg">The stop loss leg</param>
     /// <param name="symbolMapper">The symbol mapper used to convert the Lean symbol into the brokerage symbol</param>
     /// <returns>The Alpaca <see cref="AlpacaMarket.OneCancelsOtherOrder"/> ready to submit</returns>
-    public static AlpacaMarket.OneCancelsOtherOrder CreateAlpacaOneCancelsTheOtherOrder(this List<Order> orders, ISymbolMapper symbolMapper)
+    public static AlpacaMarket.OneCancelsOtherOrder CreateAlpacaOneCancelsTheOtherOrder(this LimitOrder limitLeg,
+        StopMarketOrder stopLeg, ISymbolMapper symbolMapper)
     {
-        var limitLeg = (LimitOrder)orders.Single(o => o.Type == OrderType.Limit);
-        var stopLeg = (StopMarketOrder)orders.Single(o => o.Type == OrderType.StopMarket);
-
         var brokerageSymbol = symbolMapper.GetBrokerageSymbol(limitLeg.Symbol);
         var quantity = AlpacaMarket.OrderQuantity.Fractional(limitLeg.AbsoluteQuantity);
 


### PR DESCRIPTION
#### Description

Adds one-cancels-the-other (OCO) order support. A Lean OCO group is 2 legs on the same symbol and the same side: a `LimitOrder` take profit and a `StopMarketOrder` stop loss. `PlaceOrder` now buffers the legs with `GroupOrderCacheManager` and sends them as **one** Alpaca order with `order_class=oco` — the limit leg becomes the parent order and the stop leg becomes its nested `stop_loss` leg.

```csharp
// equity: close the 100 SPY position either at a profit or at a loss, whichever price comes first
var tickets = OneCancelsTheOtherOrder(_spy, -100, limitPrice: 620m, stopPrice: 590m);
```

Both Lean legs get their own Alpaca order id before the stream lock releases: the parent id from the POST response and the child id from `response.Legs`, with one `GetOrderAsync` call as a fallback when the response has no child. This has to happen inside the lock, or the first trade update for the child leg is treated as an order placed outside Lean.

Two smaller changes on the stream side:

- `TradeEvent.Held` is now handled next to `New` and `PendingNew`. The passive leg of a group is reported as `held` and never gets a `New` event first, so without registering it here its later `canceled` event was dropped as an unknown order id.
- When a leg fills while its sibling is already `Filled`, a `BrokerageMessageEvent` warning is emitted. Alpaca documents that "in extremely volatile and fast market conditions, both orders may fill before the cancellation occurs". The client cannot prevent that, it can only report it.

**Draft:** this branch does not build against `master` yet. It needs the Lean core order-group changes (`GroupExecutionType`, `GroupOrderManager.ExecutionType`, `IBrokerageModel.SupportsGroupExecution`, and the per-leg Alpaca rules in `AlpacaBrokerageModel`), which are not open as a PR yet.

#### Related PR(s)

Lean core OCO pull request — not opened yet (branch `feature-8253-oco-order` in QuantConnect/Lean).

#### Related Issue

- #40 — an OCO pair is the exit half of a bracket order, so this is the first step of that request.
- QuantConnect/Lean#8253

#### Motivation and Context

Alpaca supports OCO natively, but Lean had no way to use it. A take profit and a stop loss went out as two separate orders with no link, so both could fill and close the position twice. With this change the broker cancels the losing leg itself.

#### Requires Documentation Change

Yes. The Alpaca supported order types page should mention one-cancels-the-other groups and their limits: 2 legs, US equities, both legs on the same side, one limit plus one stop market leg, `day` or `gtc` time in force.

#### How Has This Been Tested?

Unit test: `AlpacaBrokerageOneCancelsTheOtherOrderTests.CreateAlpacaOneCancelsTheOtherOrderBuildsExpectedRequest`, buy and sell cases. It asserts the built request has the OCO order class, the right side, the take profit limit price and the stop loss stop price.

Live paper-trading tests are written but **not run yet**:

- `OneCancelsTheOtherOrderTakeProfitLegFillsAndCancelsStopLossLeg`
- `OneCancelsTheOtherOrderStopLossLegFillsAndCancelsTakeProfitLeg`
- `OneCancelsTheOtherOrderCancelingOneLegCancelsWholeGroup`
- `HandleTradeUpdateEmitsCanceledForHeldLegWithNoPriorNewEvent`

They run once the Lean core pull request is open and this branch builds against it. Two things to confirm during that run: that the child order id really is in the POST response, and that the passive leg reports `held`.

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. <!-- live paper tests are pending; the branch needs the Lean core PR first -->
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
